### PR TITLE
Add Nockchain support

### DIFF
--- a/raycast/src/chainLogos.ts
+++ b/raycast/src/chainLogos.ts
@@ -118,6 +118,7 @@ const CHAIN_LOGO_SLUG: Record<string, string> = {
   Aleo: "aleo",
   Nano: "nano",
   Chia: "chia",
+  Nockchain: "nockchain",
   Dash: "dash",
   Urbit: "urbit",
   "Dash Testnet": "dash",

--- a/website/src/chainLogos.ts
+++ b/website/src/chainLogos.ts
@@ -120,6 +120,7 @@ export const CHAIN_LOGO: Record<string, string> = {
   Aleo: L("aleo"),
   Nano: L("nano"),
   Chia: L("chia"),
+  Nockchain: L("nockchain"),
   Dash: L("dash"),
   Urbit: L("urbit"),
   "Dash Testnet": L("dash"),

--- a/website/src/components/ResultsList.tsx
+++ b/website/src/components/ResultsList.tsx
@@ -42,6 +42,7 @@ const CLOUD_ITEMS: CloudItem[] = [
   { type: "chain", name: "Aleo" },
   { type: "chain", name: "Nano" },
   { type: "chain", name: "Chia" },
+  { type: "chain", name: "Nockchain" },
   { type: "chain", name: "Dash" },
   { type: "chain", name: "Urbit" },
   { type: "name", name: ".eth" },

--- a/worker/src/chains.ts
+++ b/worker/src/chains.ts
@@ -32,6 +32,7 @@ export type FormatFamily =
   | "nano"
   | "chia"
   | "iota"
+  | "nockchain"
   | "bitcoin-testnet";
 
 export type InputType = "address" | "transaction" | "denom" | "validator";
@@ -70,6 +71,7 @@ export interface Env {
   ETHERSCAN_API_KEY?: string;
   ALCHEMY_API_KEY?: string;
   HELIUS_API_KEY?: string;
+  NOCKBLOCKS_API_KEY?: string;
 }
 
 /** Replace {key} placeholder with the actual secret value. Returns null if key is required but missing. */
@@ -582,6 +584,19 @@ export const CHAINS: Chain[] = [
       { name: "Spacescan", baseUrl: "https://www.spacescan.io", addressPath: "/address/{query}", txPath: "/coin/{query}" },
     ],
     rpcUrls: [],
+  },
+
+  {
+    id: "nockchain",
+    name: "Nockchain",
+    symbol: "NOCK",
+    family: "nockchain",
+    explorers: [
+      { name: "NockBlocks", baseUrl: "https://nockblocks.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+    ],
+    rpcUrls: [
+      { url: "https://nockblocks.com/rpc/v1", provider: "public" },
+    ],
   },
 
   // --- Cosmos Chains ---

--- a/worker/src/detect.test.ts
+++ b/worker/src/detect.test.ts
@@ -375,11 +375,15 @@ describe("Stellar address detection", () => {
   });
 
   it("rejects lowercase", () => {
-    expect(detect("g" + "a".repeat(55), CHAINS)).toHaveLength(0);
+    const results = detect("g" + "a".repeat(55), CHAINS);
+    const stellar = results.find((r) => r.chain.id === "stellar");
+    expect(stellar).toBeUndefined();
   });
 
   it("rejects wrong length", () => {
-    expect(detect("G" + "A".repeat(54), CHAINS)).toHaveLength(0);
+    const results = detect("G" + "A".repeat(54), CHAINS);
+    const stellar = results.find((r) => r.chain.id === "stellar");
+    expect(stellar).toBeUndefined();
   });
 });
 
@@ -1140,5 +1144,44 @@ describe("Chia detection", () => {
     const results = detect(addr, CHAINS);
     const chia = results.find((r) => r.chain.id === "chia");
     expect(chia).toBeUndefined();
+  });
+});
+
+// --- Nockchain detection ---
+
+describe("Nockchain detection", () => {
+  it("detects 55-char base58 as Nockchain address and transaction", () => {
+    const addr = "51qFuv98Rg3Jg4Ka92KGdXEh16ocuzTmDZFH9wyCTeVHwaBwGSNHjWW";
+    expect(addr.length).toBe(55);
+    const results = detect(addr, CHAINS);
+    expect(results).toHaveLength(2);
+    const nock = results.filter((r) => r.chain.id === "nockchain");
+    expect(nock).toHaveLength(2);
+    expect(nock.map((r) => r.inputType).sort()).toEqual(["address", "transaction"]);
+  });
+
+  it("generates NockBlocks explorer URLs", () => {
+    const addr = "51qFuv98Rg3Jg4Ka92KGdXEh16ocuzTmDZFH9wyCTeVHwaBwGSNHjWW";
+    const results = detect(addr, CHAINS);
+    const nockAddr = results.find((r) => r.chain.id === "nockchain" && r.inputType === "address")!;
+    expect(nockAddr.explorerUrls[0].name).toBe("NockBlocks");
+    expect(nockAddr.explorerUrls[0].url).toContain("/address/");
+    const nockTx = results.find((r) => r.chain.id === "nockchain" && r.inputType === "transaction")!;
+    expect(nockTx.explorerUrls[0].url).toContain("/tx/");
+  });
+
+  it("rejects 49-char base58 (too short)", () => {
+    const addr = "5" + "A".repeat(48);
+    expect(addr.length).toBe(49);
+    const results = detect(addr, CHAINS);
+    const nock = results.find((r) => r.chain.id === "nockchain");
+    expect(nock).toBeUndefined();
+  });
+
+  it("does not conflict with Bittensor (48 chars starting with 5)", () => {
+    const addr = "5" + "F".repeat(47);
+    expect(addr.length).toBe(48);
+    const results = detect(addr, CHAINS);
+    expect(results[0].chain.id).toBe("bittensor");
   });
 });

--- a/worker/src/detect.ts
+++ b/worker/src/detect.ts
@@ -443,6 +443,15 @@ function getMatches(input: string): Match[] {
     }
   }
 
+  // Nockchain address or transaction: base58, 50-60 chars
+  // Placed after all specific-prefix chains to avoid conflicts
+  const nockchainRegex = new RegExp(`^${BASE58_CHAR}{50,60}$`);
+  if (nockchainRegex.test(trimmed)) {
+    matches.push({ chainId: "nockchain", inputType: "address" });
+    matches.push({ chainId: "nockchain", inputType: "transaction" });
+    return matches;
+  }
+
   // Solana address: base58, 32-44 chars
   const solanaAddrRegex = new RegExp(`^${BASE58_CHAR}{32,44}$`);
   if (solanaAddrRegex.test(trimmed)) {

--- a/worker/src/verify.ts
+++ b/worker/src/verify.ts
@@ -778,6 +778,32 @@ async function verifyStarknetTx(rpcUrl: string, txHash: string): Promise<boolean
   return json.result != null && !json.error;
 }
 
+// --- Nockchain ---
+
+async function verifyNockchainAddr(rpcUrl: string, address: string, apiKey: string): Promise<boolean> {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransactionsByAddress", params: [{ address }] }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) return false;
+  const json = (await response.json()) as { result?: { totalTransactions?: number } };
+  return (json.result?.totalTransactions ?? 0) > 0;
+}
+
+async function verifyNockchainTx(rpcUrl: string, txId: string, apiKey: string): Promise<boolean> {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransactionByTxid", params: [{ transactionId: txId }] }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) return false;
+  const json = (await response.json()) as { result?: { id?: string } };
+  return json.result?.id != null;
+}
+
 // --- Main verification ---
 
 async function verifyEvm(chain: Chain, inputType: string, input: string, env: Env): Promise<boolean> {
@@ -903,6 +929,12 @@ async function verifySingle(result: DetectionResult, input: string, env: Env): P
       case "chia":
       case "iota":
         return "unverified";
+      case "nockchain":
+        if (!env.NOCKBLOCKS_API_KEY) return "unverified";
+        found = isTx
+          ? await verifyNockchainTx(rpcUrls[0], input, env.NOCKBLOCKS_API_KEY)
+          : await verifyNockchainAddr(rpcUrls[0], input, env.NOCKBLOCKS_API_KEY);
+        break;
       case "xrp":
         found = await tryEndpoints(rpcUrls, (url) =>
           isTx ? verifyXrpTx(url, input) : verifyXrpAddr(url, input),


### PR DESCRIPTION
## Summary
- Add Nockchain chain config with NockBlocks explorer and JSON-RPC API verification
- Detect 50-60 char base58 strings as Nockchain address/transaction
- Requires `NOCKBLOCKS_API_KEY` worker secret for verified lookups

## Test plan
- [x] All 270 tests pass
- [ ] Set `NOCKBLOCKS_API_KEY` worker secret after merge
- [ ] Verify Nockchain address lookup works on multiscan.dev

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)