### PR TITLE
Make resolved name address click-to-copy

### DIFF
--- a/website/src/App.css
+++ b/website/src/App.css
@@ -244,8 +244,35 @@ html, body {
 }
 
 .resolution-banner__address {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  margin: -2px 0;
   color: var(--text-muted);
   font-weight: 400;
+  font-family: var(--mono);
+  font-size: inherit;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.resolution-banner__address:hover {
+  color: var(--resolve);
+  background: color-mix(in srgb, var(--resolve) 10%, transparent);
+  border-color: color-mix(in srgb, var(--resolve) 25%, transparent);
+}
+
+.resolution-banner__copy-icon {
+  opacity: 0.5;
+  transition: opacity 0.15s ease;
+}
+
+.resolution-banner__address:hover .resolution-banner__copy-icon {
+  opacity: 1;
 }
 
 /* ─── Results Section ────────────────────────────────── */

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -231,6 +231,10 @@ export default function App() {
           isLoading={isLoading}
           selectedIndex={selectedIndex}
           onSuggest={() => setShowSuggestModal(true)}
+          onCopyAddress={(addr) => {
+            navigator.clipboard.writeText(addr);
+            showToast("Copied address");
+          }}
         />
         {displayResults.length > 0 && (
           <div className="keyboard-hints">

--- a/website/src/components/ResultsList.tsx
+++ b/website/src/components/ResultsList.tsx
@@ -138,6 +138,7 @@ interface ResultsListProps {
   isLoading: boolean;
   selectedIndex: number;
   onSuggest?: () => void;
+  onCopyAddress?: (address: string) => void;
 }
 
 function truncateAddress(addr: string): string {
@@ -156,6 +157,7 @@ export default function ResultsList({
   isLoading,
   selectedIndex,
   onSuggest,
+  onCopyAddress,
 }: ResultsListProps) {
   const inputType = results[0]?.inputType;
   const isAddress = inputType === "address";
@@ -267,9 +269,21 @@ export default function ResultsList({
         <div className="resolution-banner">
           <span className="resolution-banner__name">{resolvedName}</span>
           <span className="resolution-banner__arrow">&rarr;</span>
-          <span className="resolution-banner__address">
-            {truncateAddress(resolvedAddress)}
-          </span>
+          <button
+            type="button"
+            className="resolution-banner__address"
+            onClick={() => onCopyAddress?.(resolvedAddress)}
+            title="Copy address"
+            aria-label={`Copy address ${resolvedAddress}`}
+          >
+            <span className="resolution-banner__address-text">
+              {truncateAddress(resolvedAddress)}
+            </span>
+            <svg className="resolution-banner__copy-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+          </button>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Make the resolved address in the name-resolution banner click-to-copy.

When a name (e.g. `toly.sol`, `vitalik.eth`) resolves, the banner shows `name → 0xabc…def`. Previously the address was static text. Now it's a button that copies the **full** resolved address to the clipboard, with a copy icon and a "Copied address" toast.

## Changes
- `website/src/components/ResultsList.tsx` — banner address is now a `<button>` with a copy icon, wired to a new `onCopyAddress` prop (copies the full, untruncated address).
- `website/src/App.tsx` — passes `onCopyAddress`, which writes to the clipboard and shows the existing toast.
- `website/src/App.css` — hover state (tint + border) and a copy icon that fades in on hover.

## Notes
Already deployed to production (multiscan.dev, version `20f86c73`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)