### PR TITLE
Format entire codebase with Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# Dependencies & build output
+node_modules/
+**/dist/
+.wrangler/
+.raycast/
+
+# Lockfiles (managed by npm)
+package-lock.json
+**/package-lock.json
+
+# Generated
+*.tsbuildinfo
+**/*.tsbuildinfo
+
+# Local tooling / settings
+.claude/

--- a/TESTNET_COVERAGE.md
+++ b/TESTNET_COVERAGE.md
@@ -3,75 +3,80 @@
 ## Supported Testnets
 
 ### Auto-detected (unique address format)
+
 These testnets have address formats distinguishable from mainnet, so they are automatically detected:
 
-| Chain | Testnet | Detection |
-|-------|---------|-----------|
-| Bitcoin | Bitcoin Testnet | `tb1` bech32 / `m`/`n` legacy prefix |
-| Cardano | Cardano Preprod | `addr_test1` prefix |
-| NEAR | NEAR Testnet | `.testnet` suffix |
-| Litecoin | Litecoin Testnet | `tltc1` bech32 prefix |
-| Filecoin | Filecoin Calibration | `t0`-`t4` prefix (vs `f0`-`f4`) |
-| Kaspa | Kaspa Testnet | `kaspatest:` prefix (vs `kaspa:`) |
+| Chain        | Testnet              | Detection                             |
+| ------------ | -------------------- | ------------------------------------- |
+| Bitcoin      | Bitcoin Testnet      | `tb1` bech32 / `m`/`n` legacy prefix  |
+| Cardano      | Cardano Preprod      | `addr_test1` prefix                   |
+| NEAR         | NEAR Testnet         | `.testnet` suffix                     |
+| Litecoin     | Litecoin Testnet     | `tltc1` bech32 prefix                 |
+| Filecoin     | Filecoin Calibration | `t0`-`t4` prefix (vs `f0`-`f4`)       |
+| Kaspa        | Kaspa Testnet        | `kaspatest:` prefix (vs `kaspa:`)     |
 | Bitcoin Cash | Bitcoin Cash Testnet | `bchtest:` prefix (vs `bitcoincash:`) |
 
 ### Included but not auto-detected (same address format as mainnet)
+
 These testnets share the same address format as mainnet. They exist in the chain registry for explorer URLs but cannot be automatically distinguished from mainnet addresses:
 
-| Chain | Testnet(s) | Why not auto-detected |
-|-------|-----------|----------------------|
-| Ethereum | Sepolia, Holesky | Same 0x + 40 hex address format |
-| Base | Base Sepolia | Same EVM address format |
-| Arbitrum | Arbitrum Sepolia | Same EVM address format |
-| Optimism | Optimism Sepolia | Same EVM address format |
-| Polygon | Polygon Amoy | Same EVM address format |
-| BSC | BSC Testnet | Same EVM address format |
-| Avalanche | Avalanche Fuji | Same EVM address format |
-| Fantom | Fantom Testnet | Same EVM address format |
-| zkSync Era | zkSync Sepolia | Same EVM address format |
-| Linea | Linea Sepolia | Same EVM address format |
-| Scroll | Scroll Sepolia | Same EVM address format |
-| Mantle | Mantle Sepolia | Same EVM address format |
-| Ethereum Classic | Ethereum Classic Mordor | Same EVM address format |
-| HyperEVM | HyperEVM Testnet | Same EVM address format |
-| HyperCore | HyperCore Testnet | Same EVM address format |
-| Solana | Solana Testnet, Devnet | Same base58 address format |
-| Sui | Sui Testnet | Same 0x + 64 hex format |
-| Aptos | Aptos Testnet | Same 0x + 64 hex format |
-| Tron | Tron Shasta, Nile | Same T + base58 format |
-| TON | TON Testnet | Same EQ/UQ format |
-| Starknet | Starknet Sepolia | Same 0x + 64 hex format |
-| XRP | XRP Testnet | Same r + base58 format |
-| Stellar | Stellar Testnet | Same G + base32 format |
-| Hedera | Hedera Testnet | Same 0.0.xxx format |
-| Algorand | Algorand Testnet | Same 58-char base32 format |
-| MultiversX | MultiversX Devnet | Same erd1 + bech32 format |
-| Polkadot | Polkadot Westend | SS58 prefix `5` conflicts with Bittensor |
-| Dogecoin | Dogecoin Testnet | `n`/`m` prefix conflicts with Bitcoin Testnet; not auto-detected |
-| ZCash | ZCash Testnet | Same `t1`/`t3` transparent address prefix as mainnet |
-| Dash | Dash Testnet | Same address format as mainnet |
-| Lightning | Lightning Testnet | Same node pubkey format as mainnet |
-| Osmosis | Osmosis Testnet | Same `osmo` bech32 prefix as mainnet |
-| Celestia | Celestia Testnet | Same `celestia` bech32 prefix as mainnet |
-| dYdX | dYdX Testnet | Same `dydx` bech32 prefix as mainnet |
-| Injective | Injective Testnet | Same `inj` bech32 prefix as mainnet |
-| Axelar | Axelar Testnet | Same `axelar` bech32 prefix as mainnet |
-| Kava | Kava Testnet | Same `kava` bech32 prefix as mainnet |
-| Persistence | Persistence Testnet | Same `persistence` bech32 prefix as mainnet |
-| Archway | Archway Testnet | Same `archway` bech32 prefix as mainnet |
-| Noble | Noble Testnet | Same `noble` bech32 prefix as mainnet |
-| Neutron | Neutron Testnet | Same `neutron` bech32 prefix as mainnet |
-| Coreum | Coreum Testnet | Same `core` bech32 prefix as mainnet |
-| MANTRA | MANTRA Testnet | Same `mantra` bech32 prefix as mainnet |
-| Babylon | Babylon Testnet | Same `bbn` bech32 prefix as mainnet |
+| Chain            | Testnet(s)              | Why not auto-detected                                            |
+| ---------------- | ----------------------- | ---------------------------------------------------------------- |
+| Ethereum         | Sepolia, Holesky        | Same 0x + 40 hex address format                                  |
+| Base             | Base Sepolia            | Same EVM address format                                          |
+| Arbitrum         | Arbitrum Sepolia        | Same EVM address format                                          |
+| Optimism         | Optimism Sepolia        | Same EVM address format                                          |
+| Polygon          | Polygon Amoy            | Same EVM address format                                          |
+| BSC              | BSC Testnet             | Same EVM address format                                          |
+| Avalanche        | Avalanche Fuji          | Same EVM address format                                          |
+| Fantom           | Fantom Testnet          | Same EVM address format                                          |
+| zkSync Era       | zkSync Sepolia          | Same EVM address format                                          |
+| Linea            | Linea Sepolia           | Same EVM address format                                          |
+| Scroll           | Scroll Sepolia          | Same EVM address format                                          |
+| Mantle           | Mantle Sepolia          | Same EVM address format                                          |
+| Ethereum Classic | Ethereum Classic Mordor | Same EVM address format                                          |
+| HyperEVM         | HyperEVM Testnet        | Same EVM address format                                          |
+| HyperCore        | HyperCore Testnet       | Same EVM address format                                          |
+| Solana           | Solana Testnet, Devnet  | Same base58 address format                                       |
+| Sui              | Sui Testnet             | Same 0x + 64 hex format                                          |
+| Aptos            | Aptos Testnet           | Same 0x + 64 hex format                                          |
+| Tron             | Tron Shasta, Nile       | Same T + base58 format                                           |
+| TON              | TON Testnet             | Same EQ/UQ format                                                |
+| Starknet         | Starknet Sepolia        | Same 0x + 64 hex format                                          |
+| XRP              | XRP Testnet             | Same r + base58 format                                           |
+| Stellar          | Stellar Testnet         | Same G + base32 format                                           |
+| Hedera           | Hedera Testnet          | Same 0.0.xxx format                                              |
+| Algorand         | Algorand Testnet        | Same 58-char base32 format                                       |
+| MultiversX       | MultiversX Devnet       | Same erd1 + bech32 format                                        |
+| Polkadot         | Polkadot Westend        | SS58 prefix `5` conflicts with Bittensor                         |
+| Dogecoin         | Dogecoin Testnet        | `n`/`m` prefix conflicts with Bitcoin Testnet; not auto-detected |
+| ZCash            | ZCash Testnet           | Same `t1`/`t3` transparent address prefix as mainnet             |
+| Dash             | Dash Testnet            | Same address format as mainnet                                   |
+| Lightning        | Lightning Testnet       | Same node pubkey format as mainnet                               |
+| Osmosis          | Osmosis Testnet         | Same `osmo` bech32 prefix as mainnet                             |
+| Celestia         | Celestia Testnet        | Same `celestia` bech32 prefix as mainnet                         |
+| dYdX             | dYdX Testnet            | Same `dydx` bech32 prefix as mainnet                             |
+| Injective        | Injective Testnet       | Same `inj` bech32 prefix as mainnet                              |
+| Axelar           | Axelar Testnet          | Same `axelar` bech32 prefix as mainnet                           |
+| Kava             | Kava Testnet            | Same `kava` bech32 prefix as mainnet                             |
+| Persistence      | Persistence Testnet     | Same `persistence` bech32 prefix as mainnet                      |
+| Archway          | Archway Testnet         | Same `archway` bech32 prefix as mainnet                          |
+| Noble            | Noble Testnet           | Same `noble` bech32 prefix as mainnet                            |
+| Neutron          | Neutron Testnet         | Same `neutron` bech32 prefix as mainnet                          |
+| Coreum           | Coreum Testnet          | Same `core` bech32 prefix as mainnet                             |
+| MANTRA           | MANTRA Testnet          | Same `mantra` bech32 prefix as mainnet                           |
+| Babylon          | Babylon Testnet         | Same `bbn` bech32 prefix as mainnet                              |
 
 ## Not Supported
 
 ### Cosmos SDK chains without Mintscan testnet
+
 The following Cosmos chains do not have a testnet listed on Mintscan: Cosmos Hub, Sei, Stride, Stargaze, Akash, Juno, Evmos, Secret, Band, Fetch.ai, Regen, Sentinel, Sommelier, Chihuahua, KYVE, Agoric, OmniFlix, Terra, Gravity Bridge, IRISnet, Cronos POS, Dymension, Nolus, Pryzm.
 
 ### Monero
+
 **Reason:** Monero stagenet exists but has no public block explorer. Monero's privacy-focused architecture makes testnet exploration infrastructure rare.
 
 ### Bittensor
+
 **Reason:** No standard testnet with a public block explorer. Bittensor's testnet infrastructure is focused on subnet testing rather than general-purpose exploration.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "multiscan",
   "private": true,
-  "workspaces": ["raycast", "worker", "website"],
+  "workspaces": [
+    "raycast",
+    "worker",
+    "website"
+  ],
   "scripts": {
     "dev:worker": "npm run dev --workspace=worker",
     "dev:website": "npm run dev --workspace=website",

--- a/raycast/package.json
+++ b/raycast/package.json
@@ -4,7 +4,10 @@
   "description": "Multiscan — paste any crypto address or transaction hash, auto-detect the chain, and open the block explorer",
   "icon": "command-icon.png",
   "author": "sunnya97",
-  "categories": ["Finance", "Web"],
+  "categories": [
+    "Finance",
+    "Web"
+  ],
   "license": "MIT",
   "commands": [
     {

--- a/raycast/raycast-env.d.ts
+++ b/raycast/raycast-env.d.ts
@@ -9,65 +9,64 @@
 
 type ExtensionPreferences = {
   /** Worker URL - URL of the crypto-lookup Cloudflare Worker */
-  "workerUrl": string,
+  workerUrl: string;
   /** Ethereum Explorer - Base URL for Ethereum block explorer */
-  "explorerEthereum": string,
+  explorerEthereum: string;
   /** Base Explorer - Base URL for Base block explorer */
-  "explorerBase": string,
+  explorerBase: string;
   /** Arbitrum Explorer - Base URL for Arbitrum block explorer */
-  "explorerArbitrum": string,
+  explorerArbitrum: string;
   /** Optimism Explorer - Base URL for Optimism block explorer */
-  "explorerOptimism": string,
+  explorerOptimism: string;
   /** Polygon Explorer - Base URL for Polygon block explorer */
-  "explorerPolygon": string,
+  explorerPolygon: string;
   /** BSC Explorer - Base URL for BSC block explorer */
-  "explorerBSC": string,
+  explorerBSC: string;
   /** Avalanche Explorer - Base URL for Avalanche block explorer */
-  "explorerAvalanche": string,
+  explorerAvalanche: string;
   /** Fantom Explorer - Base URL for Fantom block explorer */
-  "explorerFantom": string,
+  explorerFantom: string;
   /** zkSync Era Explorer - Base URL for zkSync Era block explorer */
-  "explorerZkSync": string,
+  explorerZkSync: string;
   /** Linea Explorer - Base URL for Linea block explorer */
-  "explorerLinea": string,
+  explorerLinea: string;
   /** Scroll Explorer - Base URL for Scroll block explorer */
-  "explorerScroll": string,
+  explorerScroll: string;
   /** Mantle Explorer - Base URL for Mantle block explorer */
-  "explorerMantle": string,
+  explorerMantle: string;
   /** Bitcoin Explorer - Base URL for Bitcoin block explorer */
-  "explorerBitcoin": string,
+  explorerBitcoin: string;
   /** Solana Explorer - Base URL for Solana block explorer */
-  "explorerSolana": string,
+  explorerSolana: string;
   /** Cosmos Hub Explorer - Base URL for Cosmos Hub block explorer */
-  "explorerCosmos": string,
+  explorerCosmos: string;
   /** Osmosis Explorer - Base URL for Osmosis block explorer */
-  "explorerOsmosis": string,
+  explorerOsmosis: string;
   /** Celestia Explorer - Base URL for Celestia block explorer */
-  "explorerCelestia": string,
+  explorerCelestia: string;
   /** Sui Explorer - Base URL for Sui block explorer */
-  "explorerSui": string,
+  explorerSui: string;
   /** Aptos Explorer - Base URL for Aptos block explorer */
-  "explorerAptos": string,
+  explorerAptos: string;
   /** Tron Explorer - Base URL for Tron block explorer */
-  "explorerTron": string,
+  explorerTron: string;
   /** TON Explorer - Base URL for TON block explorer */
-  "explorerTON": string,
+  explorerTON: string;
   /** Polkadot Explorer - Base URL for Polkadot block explorer */
-  "explorerPolkadot": string,
+  explorerPolkadot: string;
   /** NEAR Explorer - Base URL for NEAR block explorer */
-  "explorerNEAR": string
-}
+  explorerNEAR: string;
+};
 
 /** Preferences accessible in all the extension's commands */
-declare type Preferences = ExtensionPreferences
+declare type Preferences = ExtensionPreferences;
 
 declare namespace Preferences {
   /** Preferences accessible in the `search` command */
-  export type Search = ExtensionPreferences & {}
+  export type Search = ExtensionPreferences & {};
 }
 
 declare namespace Arguments {
   /** Arguments passed to the `search` command */
-  export type Search = {}
+  export type Search = {};
 }
-

--- a/raycast/src/search.tsx
+++ b/raycast/src/search.tsx
@@ -1,4 +1,13 @@
-import { Action, ActionPanel, Clipboard, Color, Icon, LaunchProps, List, getPreferenceValues } from "@raycast/api";
+import {
+  Action,
+  ActionPanel,
+  Clipboard,
+  Color,
+  Icon,
+  LaunchProps,
+  List,
+  getPreferenceValues,
+} from "@raycast/api";
 import { usePromise } from "@raycast/utils";
 import { useEffect, useMemo, useState } from "react";
 import { getExplorerOverrides } from "./chains";
@@ -15,7 +24,6 @@ interface DisplayResult {
   isToken?: boolean;
   isTestnet?: boolean;
 }
-
 
 function applyExplorerOverride(
   result: LookupResult,
@@ -35,7 +43,9 @@ function applyExplorerOverride(
       if (basePath && relativePath.startsWith(basePath)) {
         relativePath = relativePath.slice(basePath.length);
       }
-    } catch { /* invalid override URL, use full pathname */ }
+    } catch {
+      /* invalid override URL, use full pathname */
+    }
     const cleanBase = overrideBaseUrl.replace(/\/+$/, "");
     const overriddenUrl = `${cleanBase}${relativePath}${originalUrl.hash}`;
     explorerUrls = [
@@ -67,7 +77,11 @@ function truncateAddress(addr: string): string {
   return `${addr.slice(0, 8)}...${addr.slice(-6)}`;
 }
 
-async function fetchWorker(input: string, workerUrl: string, verify: boolean): Promise<WorkerResponse> {
+async function fetchWorker(
+  input: string,
+  workerUrl: string,
+  verify: boolean,
+): Promise<WorkerResponse> {
   const response = await fetch(`${workerUrl}/lookup`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -83,7 +97,9 @@ async function fetchWorker(input: string, workerUrl: string, verify: boolean): P
 
 export default function SearchCommand(props: LaunchProps) {
   const [searchText, setSearchText] = useState(props.fallbackText ?? "");
-  const [verifiedResults, setVerifiedResults] = useState<LookupResult[] | null>(null);
+  const [verifiedResults, setVerifiedResults] = useState<LookupResult[] | null>(
+    null,
+  );
   const [verifyingInput, setVerifyingInput] = useState("");
   const [resolvedName, setResolvedName] = useState<string | null>(null);
   const [resolvedAddress, setResolvedAddress] = useState<string | null>(null);
@@ -115,10 +131,7 @@ export default function SearchCommand(props: LaunchProps) {
   const explorerOverrides = useMemo(() => getExplorerOverrides(), []);
 
   // Phase 1: instant detection (verify=false)
-  const {
-    data: detectResponse,
-    isLoading: isDetecting,
-  } = usePromise(
+  const { data: detectResponse, isLoading: isDetecting } = usePromise(
     async (input: string) => {
       if (!input.trim()) return null;
       const resp = await fetchWorker(input.trim(), workerUrl, false);
@@ -153,7 +166,11 @@ export default function SearchCommand(props: LaunchProps) {
   const trimmedSearch = searchText.trim();
   const phase2Input = resolvedAddress ?? trimmedSearch;
   useEffect(() => {
-    if (!detectResults || detectResults.length <= 1 || trimmedSearch !== verifyingInput) {
+    if (
+      !detectResults ||
+      detectResults.length <= 1 ||
+      trimmedSearch !== verifyingInput
+    ) {
       // Clear stale verified results when input changes
       if (trimmedSearch !== verifyingInput) {
         setVerifiedResults(null);
@@ -171,18 +188,28 @@ export default function SearchCommand(props: LaunchProps) {
         setCoinGeckoUrl(resp.coinGeckoUrl ?? null);
       }
     });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [detectResults, trimmedSearch]);
 
   // Use verified results when available, otherwise detection results
-  const lookupResults = (verifiedResults && verifyingInput === trimmedSearch) ? verifiedResults : detectResults;
-  const isVerifying = !!detectResults && detectResults.length > 1 && (!verifiedResults || verifyingInput !== trimmedSearch);
+  const lookupResults =
+    verifiedResults && verifyingInput === trimmedSearch
+      ? verifiedResults
+      : detectResults;
+  const isVerifying =
+    !!detectResults &&
+    detectResults.length > 1 &&
+    (!verifiedResults || verifyingInput !== trimmedSearch);
   const isLoading = isDetecting || isVerifying;
 
   // Apply local explorer overrides — hide results while verifying to avoid flash of unverified list
   const displayResults: DisplayResult[] = useMemo(() => {
     if (!lookupResults || lookupResults.length === 0 || isVerifying) return [];
-    return lookupResults.map((r) => applyExplorerOverride(r, explorerOverrides));
+    return lookupResults.map((r) =>
+      applyExplorerOverride(r, explorerOverrides),
+    );
   }, [lookupResults, explorerOverrides, isVerifying]);
 
   // Determine section grouping
@@ -190,16 +217,26 @@ export default function SearchCommand(props: LaunchProps) {
   const isAddress = inputType === "address";
 
   const foundResults = displayResults.filter((r) => r.status === "found");
-  const unverifiedResults = displayResults.filter((r) => r.status === "unverified");
+  const unverifiedResults = displayResults.filter(
+    (r) => r.status === "unverified",
+  );
 
   // For addresses: if all results are unverified (no activity anywhere), show as "All Matching"
-  const addressFallback = isAddress && displayResults.length > 1 && foundResults.length === 0 && unverifiedResults.length === displayResults.length;
+  const addressFallback =
+    isAddress &&
+    displayResults.length > 1 &&
+    foundResults.length === 0 &&
+    unverifiedResults.length === displayResults.length;
 
   const sectioned = useMemo(() => {
     if (addressFallback) {
       return { allMatching: displayResults, verified: [], unverified: [] };
     }
-    return { allMatching: [], verified: foundResults, unverified: unverifiedResults };
+    return {
+      allMatching: [],
+      verified: foundResults,
+      unverified: unverifiedResults,
+    };
   }, [addressFallback, displayResults, foundResults, unverifiedResults]);
 
   // The address to show in copy actions — resolved address or raw input
@@ -248,7 +285,10 @@ export default function SearchCommand(props: LaunchProps) {
             accessories={[{ tag: { value: "Resolved", color: Color.Purple } }]}
             actions={
               <ActionPanel>
-                <Action.CopyToClipboard title="Copy Resolved Address" content={resolvedAddress} />
+                <Action.CopyToClipboard
+                  title="Copy Resolved Address"
+                  content={resolvedAddress}
+                />
                 <Action.CopyToClipboard
                   title="Copy Name"
                   content={resolvedName}
@@ -263,7 +303,12 @@ export default function SearchCommand(props: LaunchProps) {
       {sectioned.allMatching.length > 0 && (
         <List.Section title="No activity found — potential matches">
           {sectioned.allMatching.map((result) => (
-            <ResultItem key={`${result.chainId}-${result.inputType}`} result={result} query={copyAddress} coinGeckoUrl={coinGeckoUrl} />
+            <ResultItem
+              key={`${result.chainId}-${result.inputType}`}
+              result={result}
+              query={copyAddress}
+              coinGeckoUrl={coinGeckoUrl}
+            />
           ))}
         </List.Section>
       )}
@@ -271,15 +316,29 @@ export default function SearchCommand(props: LaunchProps) {
       {sectioned.verified.length > 0 && (
         <List.Section title="Verified">
           {sectioned.verified.map((result) => (
-            <ResultItem key={`${result.chainId}-${result.inputType}`} result={result} query={copyAddress} coinGeckoUrl={coinGeckoUrl} />
+            <ResultItem
+              key={`${result.chainId}-${result.inputType}`}
+              result={result}
+              query={copyAddress}
+              coinGeckoUrl={coinGeckoUrl}
+            />
           ))}
         </List.Section>
       )}
 
       {sectioned.unverified.length > 0 && (
-        <List.Section title={sectioned.verified.length > 0 ? "Other Chains" : "Detected Chains"}>
+        <List.Section
+          title={
+            sectioned.verified.length > 0 ? "Other Chains" : "Detected Chains"
+          }
+        >
           {sectioned.unverified.map((result) => (
-            <ResultItem key={`${result.chainId}-${result.inputType}`} result={result} query={copyAddress} coinGeckoUrl={coinGeckoUrl} />
+            <ResultItem
+              key={`${result.chainId}-${result.inputType}`}
+              result={result}
+              query={copyAddress}
+              coinGeckoUrl={coinGeckoUrl}
+            />
           ))}
         </List.Section>
       )}
@@ -287,14 +346,40 @@ export default function SearchCommand(props: LaunchProps) {
   );
 }
 
-function ResultItem({ result, query, coinGeckoUrl }: { result: DisplayResult; query: string; coinGeckoUrl?: string | null }) {
-  const { chainId, chainName, symbol, inputType, explorerUrls, status, isToken, isTestnet } = result;
-  const typeLabel = inputType === "address" ? "Address" : inputType === "validator" ? "Validator" : inputType === "denom" ? "Denom" : "Transaction";
-  const tagColor = inputType === "address" || inputType === "validator" ? Color.Blue : Color.Green;
+function ResultItem({
+  result,
+  query,
+  coinGeckoUrl,
+}: {
+  result: DisplayResult;
+  query: string;
+  coinGeckoUrl?: string | null;
+}) {
+  const {
+    chainId,
+    chainName,
+    symbol,
+    inputType,
+    explorerUrls,
+    status,
+    isToken,
+    isTestnet,
+  } = result;
+  const typeLabel =
+    inputType === "address"
+      ? "Address"
+      : inputType === "validator"
+        ? "Validator"
+        : inputType === "denom"
+          ? "Denom"
+          : "Transaction";
+  const tagColor =
+    inputType === "address" || inputType === "validator"
+      ? Color.Blue
+      : Color.Green;
 
   const primaryUrl = explorerUrls[0]?.url ?? "";
   const additionalExplorers = explorerUrls.slice(1);
-
 
   const logoUrl = getChainLogoUrl(chainName);
 
@@ -305,7 +390,10 @@ function ResultItem({ result, query, coinGeckoUrl }: { result: DisplayResult; qu
   }
 
   if (status === "found") {
-    accessories.push({ icon: { source: Icon.Checkmark, tintColor: Color.Green }, tooltip: "Verified on-chain" });
+    accessories.push({
+      icon: { source: Icon.Checkmark, tintColor: Color.Green },
+      tooltip: "Verified on-chain",
+    });
   }
 
   if (isToken) {
@@ -324,14 +412,28 @@ function ResultItem({ result, query, coinGeckoUrl }: { result: DisplayResult; qu
       accessories={accessories}
       actions={
         <ActionPanel>
-          <Action.OpenInBrowser title={`Open in ${explorerUrls[0]?.name ?? "Explorer"}`} url={primaryUrl} />
+          <Action.OpenInBrowser
+            title={`Open in ${explorerUrls[0]?.name ?? "Explorer"}`}
+            url={primaryUrl}
+          />
           {isToken && coinGeckoUrl && (
-            <Action.OpenInBrowser title="Open in CoinGecko" url={coinGeckoUrl} />
+            <Action.OpenInBrowser
+              title="Open in CoinGecko"
+              url={coinGeckoUrl}
+            />
           )}
           {additionalExplorers.map((explorer) => (
-            <Action.OpenInBrowser key={explorer.name} title={`Open in ${explorer.name}`} url={explorer.url} />
+            <Action.OpenInBrowser
+              key={explorer.name}
+              title={`Open in ${explorer.name}`}
+              url={explorer.url}
+            />
           ))}
-          <Action.CopyToClipboard title="Copy Explorer URL" content={primaryUrl} shortcut={{ modifiers: ["cmd"], key: "c" }} />
+          <Action.CopyToClipboard
+            title="Copy Explorer URL"
+            content={primaryUrl}
+            shortcut={{ modifiers: ["cmd"], key: "c" }}
+          />
           <Action.CopyToClipboard
             title="Copy Input"
             content={query.trim()}

--- a/website/index.html
+++ b/website/index.html
@@ -1,11 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Multiscan — Universal Crypto Explorer</title>
-    <meta name="description" content="Paste any crypto address, transaction hash, or name — auto-detect the chain and open the block explorer." />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔍</text></svg>" />
+    <meta
+      name="description"
+      content="Paste any crypto address, transaction hash, or name — auto-detect the chain and open the block explorer."
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔍</text></svg>"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/website/src/App.css
+++ b/website/src/App.css
@@ -1,8 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;600&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;600&display=swap");
 
 /* ─── Reset ──────────────────────────────────────────── */
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -31,8 +33,8 @@
   --resolve: #c084fc;
   --resolve-dim: rgba(192, 132, 252, 0.12);
   --danger: #f87171;
-  --mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
-  --sans: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
+  --sans: "DM Sans", -apple-system, BlinkMacSystemFont, sans-serif;
   --radius: 8px;
   --radius-sm: 5px;
 }
@@ -64,7 +66,8 @@
 
 /* ─── Body ───────────────────────────────────────────── */
 
-html, body {
+html,
+body {
   height: 100%;
   font-family: var(--sans);
   background: var(--bg);
@@ -132,31 +135,44 @@ html, body {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 0 16px;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
   position: relative;
   overflow: hidden;
 }
 
 .search-bar:focus-within {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-dim), 0 2px 12px var(--accent-glow);
+  box-shadow:
+    0 0 0 3px var(--accent-dim),
+    0 2px 12px var(--accent-glow);
 }
 
 .search-bar--scanning::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, transparent, var(--accent-dim), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--accent-dim),
+    transparent
+  );
   animation: scanline 1.5s ease-in-out infinite;
   pointer-events: none;
 }
 
 @keyframes scanline {
-  0% { left: -100%; }
-  100% { left: 100%; }
+  0% {
+    left: -100%;
+  }
+  100% {
+    left: 100%;
+  }
 }
 
 .search-bar__prompt {
@@ -208,8 +224,15 @@ html, body {
 }
 
 @keyframes pulse-dot {
-  0%, 100% { opacity: 0.3; transform: scale(0.8); }
-  50% { opacity: 1; transform: scale(1.2); }
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.2);
+  }
 }
 
 /* ─── Results ────────────────────────────────────────── */
@@ -257,7 +280,10 @@ html, body {
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .resolution-banner__address:hover {
@@ -313,7 +339,9 @@ html, body {
   border-radius: var(--radius);
   padding: 14px 16px;
   margin-bottom: 6px;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
   animation: fadeSlideIn 0.35s ease-out both;
 }
 
@@ -325,7 +353,9 @@ html, body {
 .result-card--selected {
   border-color: var(--accent);
   background: var(--bg-elevated);
-  box-shadow: 0 0 0 1px var(--accent-dim), 0 2px 8px var(--accent-glow);
+  box-shadow:
+    0 0 0 1px var(--accent-dim),
+    0 2px 8px var(--accent-glow);
 }
 
 .result-card__header {
@@ -438,7 +468,10 @@ html, body {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
   white-space: nowrap;
 }
 
@@ -492,11 +525,21 @@ html, body {
   animation: fadeSlideIn 0.4s ease-out both;
 }
 
-.integrations__group:nth-child(1) { animation-delay: 0.05s; }
-.integrations__group:nth-child(2) { animation-delay: 0.1s; }
-.integrations__group:nth-child(3) { animation-delay: 0.15s; }
-.integrations__group:nth-child(4) { animation-delay: 0.2s; }
-.integrations__group:nth-child(5) { animation-delay: 0.25s; }
+.integrations__group:nth-child(1) {
+  animation-delay: 0.05s;
+}
+.integrations__group:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.integrations__group:nth-child(3) {
+  animation-delay: 0.15s;
+}
+.integrations__group:nth-child(4) {
+  animation-delay: 0.2s;
+}
+.integrations__group:nth-child(5) {
+  animation-delay: 0.25s;
+}
 
 .integrations__label {
   flex-shrink: 0;
@@ -525,7 +568,9 @@ html, body {
   border: 1px solid var(--border);
   border-radius: 3px;
   padding: 2px 7px;
-  transition: color 0.2s, border-color 0.2s;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
 }
 
 .integrations__tag:hover {
@@ -610,7 +655,9 @@ html, body {
   border-radius: 3px;
   padding: 2px 7px;
   gap: 4px;
-  transition: color 0.2s, border-color 0.2s;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
 }
 
 .integrations__tag--group:hover {
@@ -674,14 +721,19 @@ html, body {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   text-decoration: none;
-  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s,
+    background 0.2s;
   animation: fadeSlideIn 0.4s ease-out 0.3s both;
 }
 
 .raycast-cta:hover {
   border-color: #ff6363;
   background: var(--bg-elevated);
-  box-shadow: 0 0 0 3px rgba(255, 99, 99, 0.08), 0 2px 12px rgba(255, 99, 99, 0.04);
+  box-shadow:
+    0 0 0 3px rgba(255, 99, 99, 0.08),
+    0 2px 12px rgba(255, 99, 99, 0.04);
 }
 
 .raycast-cta__icon {
@@ -694,7 +746,9 @@ html, body {
 .raycast-cta__arrow {
   flex-shrink: 0;
   opacity: 0.4;
-  transition: opacity 0.2s, transform 0.2s;
+  transition:
+    opacity 0.2s,
+    transform 0.2s;
 }
 
 .raycast-cta:hover .raycast-cta__arrow {
@@ -782,19 +836,31 @@ html, body {
   font-weight: 500;
   padding: 8px 16px;
   border-radius: var(--radius);
-  animation: toastIn 0.2s ease-out, toastOut 0.3s ease-in 1.5s forwards;
+  animation:
+    toastIn 0.2s ease-out,
+    toastOut 0.3s ease-in 1.5s forwards;
   pointer-events: none;
   z-index: 100;
 }
 
 @keyframes toastIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 }
 
 @keyframes toastOut {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* ─── Keyboard Hints ─────────────────────────────────── */
@@ -848,8 +914,12 @@ html, body {
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* ─── Suggest Network Modal ──────────────────────────── */
@@ -961,7 +1031,10 @@ html, body {
   padding: 8px 16px;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: opacity 0.2s, background 0.2s, border-color 0.2s;
+  transition:
+    opacity 0.2s,
+    background 0.2s,
+    border-color 0.2s;
 }
 
 .suggest-modal__btn:disabled {

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -7,8 +7,12 @@ import SuggestNetwork from "./components/SuggestNetwork";
 
 export default function App() {
   const [searchText, setSearchText] = useState("");
-  const [detectResults, setDetectResults] = useState<LookupResult[] | null>(null);
-  const [verifiedResults, setVerifiedResults] = useState<LookupResult[] | null>(null);
+  const [detectResults, setDetectResults] = useState<LookupResult[] | null>(
+    null,
+  );
+  const [verifiedResults, setVerifiedResults] = useState<LookupResult[] | null>(
+    null,
+  );
   const [verifyingInput, setVerifyingInput] = useState("");
   const [resolvedName, setResolvedName] = useState<string | null>(null);
   const [resolvedAddress, setResolvedAddress] = useState<string | null>(null);
@@ -81,7 +85,9 @@ export default function App() {
           setVerifyingInput(trimmed);
 
           let cancelled = false;
-          cancelPhase2Ref.current = () => { cancelled = true; };
+          cancelPhase2Ref.current = () => {
+            cancelled = true;
+          };
 
           const phase2Input = resp.resolvedAddress ?? trimmed;
           const verifyResp = await fetchLookup(phase2Input, true);
@@ -148,7 +154,9 @@ export default function App() {
       // ArrowDown / ArrowUp — navigate results
       if (e.key === "ArrowDown" && displayResults.length > 0) {
         e.preventDefault();
-        setSelectedIndex((prev) => Math.min(prev + 1, displayResults.length - 1));
+        setSelectedIndex((prev) =>
+          Math.min(prev + 1, displayResults.length - 1),
+        );
         return;
       }
       if (e.key === "ArrowUp" && displayResults.length > 0) {
@@ -168,7 +176,12 @@ export default function App() {
       }
 
       // Cmd/Ctrl+Shift+C — copy raw input/address
-      if (e.key === "c" && metaOrCtrl && e.shiftKey && displayResults.length > 0) {
+      if (
+        e.key === "c" &&
+        metaOrCtrl &&
+        e.shiftKey &&
+        displayResults.length > 0
+      ) {
         e.preventDefault();
         const text = resolvedAddress || trimmedSearch;
         navigator.clipboard.writeText(text);
@@ -177,7 +190,12 @@ export default function App() {
       }
 
       // Cmd/Ctrl+C — copy explorer URL (only when no text selected in input)
-      if (e.key === "c" && metaOrCtrl && !e.shiftKey && displayResults.length > 0) {
+      if (
+        e.key === "c" &&
+        metaOrCtrl &&
+        !e.shiftKey &&
+        displayResults.length > 0
+      ) {
         const selection = window.getSelection()?.toString() ?? "";
         if (selection.length > 0) return; // let native copy work
         e.preventDefault();
@@ -208,7 +226,15 @@ export default function App() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [displayResults, selectedIndex, trimmedSearch, resolvedAddress, handleSearch, showToast, showSuggestModal]);
+  }, [
+    displayResults,
+    selectedIndex,
+    trimmedSearch,
+    resolvedAddress,
+    handleSearch,
+    showToast,
+    showSuggestModal,
+  ]);
 
   return (
     <div className="app">
@@ -217,9 +243,16 @@ export default function App() {
           <h1 className="header__title">
             <span className="header__multi">Multi</span>scan
           </h1>
-          <p className="header__sub">Universal crypto address &amp; transaction scanner</p>
+          <p className="header__sub">
+            Universal crypto address &amp; transaction scanner
+          </p>
         </header>
-        <SearchBar ref={inputRef} value={searchText} onChange={handleSearch} isLoading={isLoading} />
+        <SearchBar
+          ref={inputRef}
+          value={searchText}
+          onChange={handleSearch}
+          isLoading={isLoading}
+        />
         <ResultsList
           results={displayResults}
           coinGeckoUrl={coinGeckoUrl}
@@ -238,21 +271,37 @@ export default function App() {
         />
         {displayResults.length > 0 && (
           <div className="keyboard-hints">
-            <span className="keyboard-hints__item"><kbd>{"↑↓"}</kbd> Navigate</span>
+            <span className="keyboard-hints__item">
+              <kbd>{"↑↓"}</kbd> Navigate
+            </span>
             <span className="keyboard-hints__sep">&middot;</span>
-            <span className="keyboard-hints__item"><kbd>{"↵"}</kbd> Open</span>
+            <span className="keyboard-hints__item">
+              <kbd>{"↵"}</kbd> Open
+            </span>
             <span className="keyboard-hints__sep">&middot;</span>
-            <span className="keyboard-hints__item"><kbd>{"⌘C"}</kbd> Copy URL</span>
+            <span className="keyboard-hints__item">
+              <kbd>{"⌘C"}</kbd> Copy URL
+            </span>
             <span className="keyboard-hints__sep">&middot;</span>
-            <span className="keyboard-hints__item"><kbd>{"⌘⇧C"}</kbd> Copy Input</span>
+            <span className="keyboard-hints__item">
+              <kbd>{"⌘⇧C"}</kbd> Copy Input
+            </span>
             <span className="keyboard-hints__sep">&middot;</span>
-            <span className="keyboard-hints__item"><kbd>Esc</kbd> Clear</span>
+            <span className="keyboard-hints__item">
+              <kbd>Esc</kbd> Clear
+            </span>
           </div>
         )}
         <footer className="footer">
           <span>Multiscan</span>
           <span className="footer__sep">&middot;</span>
-          <a href="https://github.com/sunnya97/multiscan" target="_blank" rel="noopener noreferrer">Open source</a>
+          <a
+            href="https://github.com/sunnya97/multiscan"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open source
+          </a>
         </footer>
       </div>
       {showSuggestModal && (

--- a/website/src/components/ResultCard.tsx
+++ b/website/src/components/ResultCard.tsx
@@ -9,10 +9,30 @@ interface ResultCardProps {
   isSelected?: boolean;
 }
 
-export default function ResultCard({ result, coinGeckoUrl, index, isSelected }: ResultCardProps) {
-  const { chainName, symbol, inputType, explorerUrls, status, isToken, isTestnet } = result;
+export default function ResultCard({
+  result,
+  coinGeckoUrl,
+  index,
+  isSelected,
+}: ResultCardProps) {
+  const {
+    chainName,
+    symbol,
+    inputType,
+    explorerUrls,
+    status,
+    isToken,
+    isTestnet,
+  } = result;
   const isVerified = status === "found";
-  const typeLabel = inputType === "address" ? "ADDR" : inputType === "transaction" ? "TX" : inputType === "validator" ? "VALIDATOR" : "DENOM";
+  const typeLabel =
+    inputType === "address"
+      ? "ADDR"
+      : inputType === "transaction"
+        ? "TX"
+        : inputType === "validator"
+          ? "VALIDATOR"
+          : "DENOM";
   const cardRef = useRef<HTMLDivElement>(null);
   const [logoBroken, setLogoBroken] = useState(false);
   const logoSrc = CHAIN_LOGO[chainName];
@@ -46,20 +66,32 @@ export default function ResultCard({ result, coinGeckoUrl, index, isSelected }: 
         </div>
         <div className="result-card__badges">
           {isTestnet && (
-            <span className="result-card__badge result-card__badge--testnet">TESTNET</span>
+            <span className="result-card__badge result-card__badge--testnet">
+              TESTNET
+            </span>
           )}
           {isVerified && (
             <span className="result-card__badge result-card__badge--verified">
               <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                <path d="M2 5.5L4 7.5L8 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                <path
+                  d="M2 5.5L4 7.5L8 3"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </svg>
               VERIFIED
             </span>
           )}
           {isToken ? (
-            <span className="result-card__badge result-card__badge--token">TOKEN</span>
+            <span className="result-card__badge result-card__badge--token">
+              TOKEN
+            </span>
           ) : (
-            <span className="result-card__badge result-card__badge--type">{typeLabel}</span>
+            <span className="result-card__badge result-card__badge--type">
+              {typeLabel}
+            </span>
           )}
         </div>
       </div>
@@ -74,7 +106,13 @@ export default function ResultCard({ result, coinGeckoUrl, index, isSelected }: 
           >
             {explorer.name}
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-              <path d="M3 1H9V7M9 1L1 9" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+              <path
+                d="M3 1H9V7M9 1L1 9"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
           </a>
         ))}
@@ -87,7 +125,13 @@ export default function ResultCard({ result, coinGeckoUrl, index, isSelected }: 
           >
             CoinGecko
             <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-              <path d="M3 1H9V7M9 1L1 9" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/>
+              <path
+                d="M3 1H9V7M9 1L1 9"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
           </a>
         )}

--- a/website/src/components/ResultsList.tsx
+++ b/website/src/components/ResultsList.tsx
@@ -5,14 +5,136 @@ import ResultCard from "./ResultCard";
 
 type CloudItem =
   | { type: "chain"; name: string }
-  | { type: "group"; id: string; label: string; preview: string[]; chains: string[] }
+  | {
+      type: "group";
+      id: string;
+      label: string;
+      preview: string[];
+      chains: string[];
+    }
   | { type: "name"; name: string };
 
 const CLOUD_ITEMS: CloudItem[] = [
   { type: "chain", name: "Bitcoin" },
-  { type: "group", id: "evm", label: "EVM", preview: ["Ethereum", "Base", "Arbitrum", "Optimism"], chains: ["Ethereum", "Base", "Arbitrum", "Optimism", "Polygon", "BSC", "Avalanche", "Fantom", "zkSync Era", "Linea", "Scroll", "Mantle", "Ethereum Classic", "HyperEVM", "Berachain", "Ronin", "Flare", "Oasis Sapphire", "Core", "Monad", "MegaETH", "Plasma", "Gnosis", "Blast", "World Chain", "Zora", "Unichain", "Celo", "Metis", "Moonbeam", "ApeChain", "Arbitrum Nova", "Polygon zkEVM", "opBNB", "Sonic", "Abstract", "Soneium", "Mode", "Boba", "BOB", "ZetaChain", "Fraxtal", "Rootstock", "Flow EVM", "Astar", "Ink", "Degen", "Shape", "Superseed", "Polynomial", "Story", "Lens", "Anime", "Citrea", "Botanix", "CrossFi", "Galactica", "Humanity", "Stable", "Mythos", "Settlus", "Syndicate", "World Mobile Chain", "ADI"] },
+  {
+    type: "group",
+    id: "evm",
+    label: "EVM",
+    preview: ["Ethereum", "Base", "Arbitrum", "Optimism"],
+    chains: [
+      "Ethereum",
+      "Base",
+      "Arbitrum",
+      "Optimism",
+      "Polygon",
+      "BSC",
+      "Avalanche",
+      "Fantom",
+      "zkSync Era",
+      "Linea",
+      "Scroll",
+      "Mantle",
+      "Ethereum Classic",
+      "HyperEVM",
+      "Berachain",
+      "Ronin",
+      "Flare",
+      "Oasis Sapphire",
+      "Core",
+      "Monad",
+      "MegaETH",
+      "Plasma",
+      "Gnosis",
+      "Blast",
+      "World Chain",
+      "Zora",
+      "Unichain",
+      "Celo",
+      "Metis",
+      "Moonbeam",
+      "ApeChain",
+      "Arbitrum Nova",
+      "Polygon zkEVM",
+      "opBNB",
+      "Sonic",
+      "Abstract",
+      "Soneium",
+      "Mode",
+      "Boba",
+      "BOB",
+      "ZetaChain",
+      "Fraxtal",
+      "Rootstock",
+      "Flow EVM",
+      "Astar",
+      "Ink",
+      "Degen",
+      "Shape",
+      "Superseed",
+      "Polynomial",
+      "Story",
+      "Lens",
+      "Anime",
+      "Citrea",
+      "Botanix",
+      "CrossFi",
+      "Galactica",
+      "Humanity",
+      "Stable",
+      "Mythos",
+      "Settlus",
+      "Syndicate",
+      "World Mobile Chain",
+      "ADI",
+    ],
+  },
   { type: "chain", name: "Solana" },
-  { type: "group", id: "cosmos", label: "Cosmos", preview: ["Cosmos Hub", "Osmosis", "Celestia", "dYdX"], chains: ["Cosmos Hub", "Osmosis", "Celestia", "dYdX", "Injective", "Sei", "Stride", "Stargaze", "Akash", "Axelar", "Kava", "Juno", "Evmos", "Secret", "Band", "Persistence", "Fetch.ai", "Regen", "Sentinel", "Sommelier", "Chihuahua", "Archway", "Noble", "Neutron", "Coreum", "KYVE", "Agoric", "OmniFlix", "Terra", "Gravity Bridge", "IRISnet", "Cronos POS", "Dymension", "MANTRA", "Babylon", "Nolus", "Pryzm", "THORChain"] },
+  {
+    type: "group",
+    id: "cosmos",
+    label: "Cosmos",
+    preview: ["Cosmos Hub", "Osmosis", "Celestia", "dYdX"],
+    chains: [
+      "Cosmos Hub",
+      "Osmosis",
+      "Celestia",
+      "dYdX",
+      "Injective",
+      "Sei",
+      "Stride",
+      "Stargaze",
+      "Akash",
+      "Axelar",
+      "Kava",
+      "Juno",
+      "Evmos",
+      "Secret",
+      "Band",
+      "Persistence",
+      "Fetch.ai",
+      "Regen",
+      "Sentinel",
+      "Sommelier",
+      "Chihuahua",
+      "Archway",
+      "Noble",
+      "Neutron",
+      "Coreum",
+      "KYVE",
+      "Agoric",
+      "OmniFlix",
+      "Terra",
+      "Gravity Bridge",
+      "IRISnet",
+      "Cronos POS",
+      "Dymension",
+      "MANTRA",
+      "Babylon",
+      "Nolus",
+      "Pryzm",
+      "THORChain",
+    ],
+  },
   { type: "chain", name: "HyperCore" },
   { type: "chain", name: "Sui" },
   { type: "chain", name: "Aptos" },
@@ -85,7 +207,8 @@ function GroupTag({ group }: { group: Extract<CloudItem, { type: "group" }> }) {
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
@@ -110,7 +233,13 @@ function GroupTag({ group }: { group: Extract<CloudItem, { type: "group" }> }) {
           viewBox="0 0 14 14"
           fill="none"
         >
-          <path d="M3.5 5.25L7 8.75L10.5 5.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          <path
+            d="M3.5 5.25L7 8.75L10.5 5.25"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
       </button>
       {open && (
@@ -175,7 +304,11 @@ export default function ResultsList({
     if (addressFallback) {
       return { allMatching: results, verified: [], unverified: [] };
     }
-    return { allMatching: [], verified: foundResults, unverified: unverifiedResults };
+    return {
+      allMatching: [],
+      verified: foundResults,
+      unverified: unverifiedResults,
+    };
   }, [addressFallback, results, foundResults, unverifiedResults]);
 
   if (isVerifying && hasInput) {
@@ -186,7 +319,9 @@ export default function ResultsList({
           <div className="scan-ring scan-ring--delayed" />
         </div>
         <p className="results-empty__title">Scanning networks...</p>
-        <p className="results-empty__sub">Verifying activity across matching chains</p>
+        <p className="results-empty__sub">
+          Verifying activity across matching chains
+        </p>
       </div>
     );
   }
@@ -204,7 +339,9 @@ export default function ResultsList({
     return (
       <div className="results-empty">
         <p className="results-empty__title">No chains detected</p>
-        <p className="results-empty__sub">Try a valid crypto address or transaction hash</p>
+        <p className="results-empty__sub">
+          Try a valid crypto address or transaction hash
+        </p>
       </div>
     );
   }
@@ -223,13 +360,37 @@ export default function ResultsList({
           rel="noopener noreferrer"
           className="raycast-cta"
         >
-          <svg className="raycast-cta__icon" width="20" height="20" viewBox="0 0 512 512" fill="none">
-            <path d="M427.2 0H84.8C38 0 0 38 0 84.8v342.4C0 474 38 512 84.8 512h342.4c46.8 0 84.8-38 84.8-84.8V84.8C512 38 474 0 427.2 0z" fill="#FF6363"/>
-            <path d="M256.7 152.4l-78.8 78.8 25.5 25.5 78.8-78.8-25.5-25.5zm-104.3 104.3l-25.5-25.5-40.5 40.5v51l15.5-15.5 50.5-50.5zm207.2-207.2h-51l40.5 40.5-25.5 25.5 25.5 25.5 50.5-50.5-15.5-15.5-24.5-25.5zm-78.8 78.8l-25.5-25.5-78.8 78.8 25.5 25.5 78.8-78.8zm-129.3 129.3l-25.5 25.5 25.5 25.5 25.5-25.5-25.5-25.5zm207.6-103.8l-25.5-25.5-78.8 78.8 25.5 25.5 78.8-78.8zM152.4 332.1l-25.5 25.5 66 66h51l-91.5-91.5zm207.2-75.3l-25.5 25.5 50.5 50.5 15.5 15.5v-51l-40.5-40.5zM256.7 281.3l-25.5 25.5 91.5 91.5h51l-117-117z" fill="white"/>
+          <svg
+            className="raycast-cta__icon"
+            width="20"
+            height="20"
+            viewBox="0 0 512 512"
+            fill="none"
+          >
+            <path
+              d="M427.2 0H84.8C38 0 0 38 0 84.8v342.4C0 474 38 512 84.8 512h342.4c46.8 0 84.8-38 84.8-84.8V84.8C512 38 474 0 427.2 0z"
+              fill="#FF6363"
+            />
+            <path
+              d="M256.7 152.4l-78.8 78.8 25.5 25.5 78.8-78.8-25.5-25.5zm-104.3 104.3l-25.5-25.5-40.5 40.5v51l15.5-15.5 50.5-50.5zm207.2-207.2h-51l40.5 40.5-25.5 25.5 25.5 25.5 50.5-50.5-15.5-15.5-24.5-25.5zm-78.8 78.8l-25.5-25.5-78.8 78.8 25.5 25.5 78.8-78.8zm-129.3 129.3l-25.5 25.5 25.5 25.5 25.5-25.5-25.5-25.5zm207.6-103.8l-25.5-25.5-78.8 78.8 25.5 25.5 78.8-78.8zM152.4 332.1l-25.5 25.5 66 66h51l-91.5-91.5zm207.2-75.3l-25.5 25.5 50.5 50.5 15.5 15.5v-51l-40.5-40.5zM256.7 281.3l-25.5 25.5 91.5 91.5h51l-117-117z"
+              fill="white"
+            />
           </svg>
           Install Raycast Extension
-          <svg className="raycast-cta__arrow" width="12" height="12" viewBox="0 0 12 12" fill="none">
-            <path d="M2 6H10M10 6L6.5 2.5M10 6L6.5 9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          <svg
+            className="raycast-cta__arrow"
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+          >
+            <path
+              d="M2 6H10M10 6L6.5 2.5M10 6L6.5 9.5"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
         </a>
 
@@ -241,7 +402,14 @@ export default function ResultsList({
                 return <GroupTag key={item.id} group={item} />;
               }
               if (item.type === "name") {
-                return <span key={item.name} className="integrations__tag integrations__tag--name">{item.name}</span>;
+                return (
+                  <span
+                    key={item.name}
+                    className="integrations__tag integrations__tag--name"
+                  >
+                    {item.name}
+                  </span>
+                );
               }
               return (
                 <span key={item.name} className="integrations__tag">
@@ -279,7 +447,18 @@ export default function ResultsList({
             <span className="resolution-banner__address-text">
               {truncateAddress(resolvedAddress)}
             </span>
-            <svg className="resolution-banner__copy-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <svg
+              className="resolution-banner__copy-icon"
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
             </svg>
@@ -290,8 +469,12 @@ export default function ResultsList({
       {sections.allMatching.length > 0 && (
         <div className="results-section">
           <div className="results-section__header">
-            <span className="results-section__label">No activity found &mdash; potential matches</span>
-            <span className="results-section__count">{sections.allMatching.length}</span>
+            <span className="results-section__label">
+              No activity found &mdash; potential matches
+            </span>
+            <span className="results-section__count">
+              {sections.allMatching.length}
+            </span>
           </div>
           {sections.allMatching.map((r) => {
             const idx = cardIndex++;
@@ -312,7 +495,9 @@ export default function ResultsList({
         <div className="results-section">
           <div className="results-section__header">
             <span className="results-section__label">Verified</span>
-            <span className="results-section__count">{sections.verified.length}</span>
+            <span className="results-section__count">
+              {sections.verified.length}
+            </span>
           </div>
           {sections.verified.map((r) => {
             const idx = cardIndex++;
@@ -333,9 +518,13 @@ export default function ResultsList({
         <div className="results-section">
           <div className="results-section__header">
             <span className="results-section__label">
-              {sections.verified.length > 0 ? "Other Chains" : "Detected Chains"}
+              {sections.verified.length > 0
+                ? "Other Chains"
+                : "Detected Chains"}
             </span>
-            <span className="results-section__count">{sections.unverified.length}</span>
+            <span className="results-section__count">
+              {sections.unverified.length}
+            </span>
           </div>
           {sections.unverified.map((r) => {
             const idx = cardIndex++;

--- a/website/src/components/SearchBar.tsx
+++ b/website/src/components/SearchBar.tsx
@@ -42,7 +42,7 @@ const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
         )}
       </div>
     );
-  }
+  },
 );
 
 export default SearchBar;

--- a/website/src/components/SuggestNetwork.tsx
+++ b/website/src/components/SuggestNetwork.tsx
@@ -101,7 +101,11 @@ export default function SuggestNetwork({ onClose }: SuggestNetworkProps) {
             {result.created ? (
               <p>
                 Suggestion created!{" "}
-                <a href={result.issueUrl} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={result.issueUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   View issue #{result.issueNumber}
                 </a>
               </p>

--- a/worker/scripts/update-cosmos-chains.ts
+++ b/worker/scripts/update-cosmos-chains.ts
@@ -13,43 +13,230 @@ const COSMOS_CHAINS: {
   symbol: string;
   mintscanSlug?: string; // defaults to chainId if not set
 }[] = [
-  { registryName: "cosmoshub", chainId: "cosmos", displayName: "Cosmos Hub", symbol: "ATOM" },
-  { registryName: "osmosis", chainId: "osmosis", displayName: "Osmosis", symbol: "OSMO" },
-  { registryName: "celestia", chainId: "celestia", displayName: "Celestia", symbol: "TIA" },
-  { registryName: "dydx", chainId: "dydx", displayName: "dYdX", symbol: "DYDX" },
-  { registryName: "injective", chainId: "injective", displayName: "Injective", symbol: "INJ" },
+  {
+    registryName: "cosmoshub",
+    chainId: "cosmos",
+    displayName: "Cosmos Hub",
+    symbol: "ATOM",
+  },
+  {
+    registryName: "osmosis",
+    chainId: "osmosis",
+    displayName: "Osmosis",
+    symbol: "OSMO",
+  },
+  {
+    registryName: "celestia",
+    chainId: "celestia",
+    displayName: "Celestia",
+    symbol: "TIA",
+  },
+  {
+    registryName: "dydx",
+    chainId: "dydx",
+    displayName: "dYdX",
+    symbol: "DYDX",
+  },
+  {
+    registryName: "injective",
+    chainId: "injective",
+    displayName: "Injective",
+    symbol: "INJ",
+  },
   { registryName: "sei", chainId: "sei", displayName: "Sei", symbol: "SEI" },
-  { registryName: "stride", chainId: "stride", displayName: "Stride", symbol: "STRD" },
-  { registryName: "stargaze", chainId: "stargaze", displayName: "Stargaze", symbol: "STARS" },
-  { registryName: "akash", chainId: "akash", displayName: "Akash", symbol: "AKT" },
-  { registryName: "axelar", chainId: "axelar", displayName: "Axelar", symbol: "AXL" },
-  { registryName: "kava", chainId: "kava", displayName: "Kava", symbol: "KAVA" },
-  { registryName: "juno", chainId: "juno", displayName: "Juno", symbol: "JUNO" },
-  { registryName: "evmos", chainId: "evmos", displayName: "Evmos", symbol: "EVMOS" },
-  { registryName: "secretnetwork", chainId: "secret", displayName: "Secret Network", symbol: "SCRT", mintscanSlug: "secret" },
-  { registryName: "bandchain", chainId: "band", displayName: "Band Protocol", symbol: "BAND", mintscanSlug: "band" },
-  { registryName: "persistence", chainId: "persistence", displayName: "Persistence", symbol: "XPRT" },
-  { registryName: "fetchhub", chainId: "fetchai", displayName: "Fetch.ai", symbol: "FET", mintscanSlug: "fetchai" },
-  { registryName: "regen", chainId: "regen", displayName: "Regen", symbol: "REGEN" },
-  { registryName: "sentinel", chainId: "sentinel", displayName: "Sentinel", symbol: "DVPN" },
-  { registryName: "sommelier", chainId: "sommelier", displayName: "Sommelier", symbol: "SOMM" },
-  { registryName: "chihuahua", chainId: "chihuahua", displayName: "Chihuahua", symbol: "HUAHUA" },
-  { registryName: "archway", chainId: "archway", displayName: "Archway", symbol: "ARCH" },
-  { registryName: "noble", chainId: "noble", displayName: "Noble", symbol: "USDC" },
-  { registryName: "neutron", chainId: "neutron", displayName: "Neutron", symbol: "NTRN" },
-  { registryName: "coreum", chainId: "coreum", displayName: "Coreum", symbol: "CORE" },
-  { registryName: "kyve", chainId: "kyve", displayName: "KYVE", symbol: "KYVE" },
-  { registryName: "agoric", chainId: "agoric", displayName: "Agoric", symbol: "BLD" },
-  { registryName: "omniflixhub", chainId: "omniflix", displayName: "OmniFlix", symbol: "FLIX", mintscanSlug: "omniflix" },
-  { registryName: "terra2", chainId: "terra", displayName: "Terra", symbol: "LUNA" },
-  { registryName: "gravitybridge", chainId: "gravity-bridge", displayName: "Gravity Bridge", symbol: "GRAV", mintscanSlug: "gravity-bridge" },
-  { registryName: "irisnet", chainId: "iris", displayName: "IRISnet", symbol: "IRIS", mintscanSlug: "iris" },
-  { registryName: "cryptoorgchain", chainId: "crypto-org", displayName: "Cronos POS", symbol: "CRO", mintscanSlug: "crypto-org" },
-  { registryName: "dymension", chainId: "dymension", displayName: "Dymension", symbol: "DYM" },
-  { registryName: "mantrachain", chainId: "mantra", displayName: "MANTRA", symbol: "OM" },
-  { registryName: "babylon", chainId: "babylon", displayName: "Babylon", symbol: "BBN" },
-  { registryName: "nolus", chainId: "nolus", displayName: "Nolus", symbol: "NLS" },
-  { registryName: "pryzm", chainId: "pryzm", displayName: "Pryzm", symbol: "PRYZM" },
+  {
+    registryName: "stride",
+    chainId: "stride",
+    displayName: "Stride",
+    symbol: "STRD",
+  },
+  {
+    registryName: "stargaze",
+    chainId: "stargaze",
+    displayName: "Stargaze",
+    symbol: "STARS",
+  },
+  {
+    registryName: "akash",
+    chainId: "akash",
+    displayName: "Akash",
+    symbol: "AKT",
+  },
+  {
+    registryName: "axelar",
+    chainId: "axelar",
+    displayName: "Axelar",
+    symbol: "AXL",
+  },
+  {
+    registryName: "kava",
+    chainId: "kava",
+    displayName: "Kava",
+    symbol: "KAVA",
+  },
+  {
+    registryName: "juno",
+    chainId: "juno",
+    displayName: "Juno",
+    symbol: "JUNO",
+  },
+  {
+    registryName: "evmos",
+    chainId: "evmos",
+    displayName: "Evmos",
+    symbol: "EVMOS",
+  },
+  {
+    registryName: "secretnetwork",
+    chainId: "secret",
+    displayName: "Secret Network",
+    symbol: "SCRT",
+    mintscanSlug: "secret",
+  },
+  {
+    registryName: "bandchain",
+    chainId: "band",
+    displayName: "Band Protocol",
+    symbol: "BAND",
+    mintscanSlug: "band",
+  },
+  {
+    registryName: "persistence",
+    chainId: "persistence",
+    displayName: "Persistence",
+    symbol: "XPRT",
+  },
+  {
+    registryName: "fetchhub",
+    chainId: "fetchai",
+    displayName: "Fetch.ai",
+    symbol: "FET",
+    mintscanSlug: "fetchai",
+  },
+  {
+    registryName: "regen",
+    chainId: "regen",
+    displayName: "Regen",
+    symbol: "REGEN",
+  },
+  {
+    registryName: "sentinel",
+    chainId: "sentinel",
+    displayName: "Sentinel",
+    symbol: "DVPN",
+  },
+  {
+    registryName: "sommelier",
+    chainId: "sommelier",
+    displayName: "Sommelier",
+    symbol: "SOMM",
+  },
+  {
+    registryName: "chihuahua",
+    chainId: "chihuahua",
+    displayName: "Chihuahua",
+    symbol: "HUAHUA",
+  },
+  {
+    registryName: "archway",
+    chainId: "archway",
+    displayName: "Archway",
+    symbol: "ARCH",
+  },
+  {
+    registryName: "noble",
+    chainId: "noble",
+    displayName: "Noble",
+    symbol: "USDC",
+  },
+  {
+    registryName: "neutron",
+    chainId: "neutron",
+    displayName: "Neutron",
+    symbol: "NTRN",
+  },
+  {
+    registryName: "coreum",
+    chainId: "coreum",
+    displayName: "Coreum",
+    symbol: "CORE",
+  },
+  {
+    registryName: "kyve",
+    chainId: "kyve",
+    displayName: "KYVE",
+    symbol: "KYVE",
+  },
+  {
+    registryName: "agoric",
+    chainId: "agoric",
+    displayName: "Agoric",
+    symbol: "BLD",
+  },
+  {
+    registryName: "omniflixhub",
+    chainId: "omniflix",
+    displayName: "OmniFlix",
+    symbol: "FLIX",
+    mintscanSlug: "omniflix",
+  },
+  {
+    registryName: "terra2",
+    chainId: "terra",
+    displayName: "Terra",
+    symbol: "LUNA",
+  },
+  {
+    registryName: "gravitybridge",
+    chainId: "gravity-bridge",
+    displayName: "Gravity Bridge",
+    symbol: "GRAV",
+    mintscanSlug: "gravity-bridge",
+  },
+  {
+    registryName: "irisnet",
+    chainId: "iris",
+    displayName: "IRISnet",
+    symbol: "IRIS",
+    mintscanSlug: "iris",
+  },
+  {
+    registryName: "cryptoorgchain",
+    chainId: "crypto-org",
+    displayName: "Cronos POS",
+    symbol: "CRO",
+    mintscanSlug: "crypto-org",
+  },
+  {
+    registryName: "dymension",
+    chainId: "dymension",
+    displayName: "Dymension",
+    symbol: "DYM",
+  },
+  {
+    registryName: "mantrachain",
+    chainId: "mantra",
+    displayName: "MANTRA",
+    symbol: "OM",
+  },
+  {
+    registryName: "babylon",
+    chainId: "babylon",
+    displayName: "Babylon",
+    symbol: "BBN",
+  },
+  {
+    registryName: "nolus",
+    chainId: "nolus",
+    displayName: "Nolus",
+    symbol: "NLS",
+  },
+  {
+    registryName: "pryzm",
+    chainId: "pryzm",
+    displayName: "Pryzm",
+    symbol: "PRYZM",
+  },
 ];
 
 interface RegistryExplorer {
@@ -83,11 +270,16 @@ async function fetchChainJson(registryName: string): Promise<RegistryChain> {
   return (await response.json()) as RegistryChain;
 }
 
-function parseExplorerPath(template: string | undefined, baseUrl: string): string | null {
+function parseExplorerPath(
+  template: string | undefined,
+  baseUrl: string,
+): string | null {
   if (!template || !baseUrl) return null;
   if (!template.startsWith(baseUrl)) return null;
   const path = template.slice(baseUrl.length);
-  return path.replace(/\$\{txHash\}/g, "{query}").replace(/\$\{accountAddress\}/g, "{query}");
+  return path
+    .replace(/\$\{txHash\}/g, "{query}")
+    .replace(/\$\{accountAddress\}/g, "{query}");
 }
 
 async function main() {
@@ -108,7 +300,8 @@ async function main() {
         .map((e) => {
           const baseUrl = e.url!.replace(/\/$/, "");
           const txPath = parseExplorerPath(e.tx_page, baseUrl) ?? "/tx/{query}";
-          const addressPath = parseExplorerPath(e.account_page, baseUrl) ?? "/address/{query}";
+          const addressPath =
+            parseExplorerPath(e.account_page, baseUrl) ?? "/address/{query}";
           return { name: e.kind ?? "Explorer", baseUrl, addressPath, txPath };
         });
 
@@ -139,8 +332,12 @@ async function main() {
       console.log(`    symbol: "${chain.symbol}",`);
       console.log(`    family: "cosmos",`);
       console.log(`    bech32Prefix: "${bech32Prefix}",`);
-      console.log(`    explorers: ${JSON.stringify(explorers, null, 6).replace(/\n/g, "\n    ")},`);
-      console.log(`    rpcUrls: ${JSON.stringify(restEndpoints, null, 6).replace(/\n/g, "\n    ")},`);
+      console.log(
+        `    explorers: ${JSON.stringify(explorers, null, 6).replace(/\n/g, "\n    ")},`,
+      );
+      console.log(
+        `    rpcUrls: ${JSON.stringify(restEndpoints, null, 6).replace(/\n/g, "\n    ")},`,
+      );
       console.log(`  },`);
     } catch (err) {
       console.error(`  // ERROR fetching ${chain.registryName}:`, err);

--- a/worker/src/chains.test.ts
+++ b/worker/src/chains.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { CHAINS, resolveRpcUrl, getAlchemyRpcUrl, getResolvedRpcUrls, type RpcEndpoint, type Chain, type Env } from "./chains";
+import {
+  CHAINS,
+  resolveRpcUrl,
+  getAlchemyRpcUrl,
+  getResolvedRpcUrls,
+  type RpcEndpoint,
+  type Chain,
+  type Env,
+} from "./chains";
 
 // --- resolveRpcUrl ---
 
 describe("resolveRpcUrl", () => {
   it("returns raw URL when no key is needed", () => {
-    const ep: RpcEndpoint = { url: "https://rpc.example.com", provider: "public" };
+    const ep: RpcEndpoint = {
+      url: "https://rpc.example.com",
+      provider: "public",
+    };
     expect(resolveRpcUrl(ep, {})).toBe("https://rpc.example.com");
   });
 
@@ -90,23 +101,71 @@ describe("CHAINS data integrity", () => {
 
   it("every chain has at least one explorer", () => {
     for (const chain of CHAINS) {
-      expect(chain.explorers.length, `${chain.id} has no explorers`).toBeGreaterThanOrEqual(1);
+      expect(
+        chain.explorers.length,
+        `${chain.id} has no explorers`,
+      ).toBeGreaterThanOrEqual(1);
     }
   });
 
   it("every chain has at least one rpcUrl (except unverifiable chains)", () => {
-    const unverifiable = new Set(["monero", "bittensor", "litecoin-testnet", "kaspa-testnet", "dogecoin-testnet", "bitcoin-cash-testnet", "zcash-testnet", "dash", "dash-testnet", "lightning-testnet", "ethereum-classic-mordor", "hyperliquid-core-testnet", "osmosis-testnet", "celestia-testnet", "dydx-testnet", "injective-testnet", "axelar-testnet", "kava-testnet", "persistence-testnet", "archway-testnet", "noble-testnet", "neutron-testnet", "coreum-testnet", "mantra-testnet", "babylon-testnet", "urbit", "berachain-testnet", "ronin-testnet", "oasis-testnet", "core-testnet", "monad-testnet", "tezos", "aleo", "nano", "chia", "iota"]);
+    const unverifiable = new Set([
+      "monero",
+      "bittensor",
+      "litecoin-testnet",
+      "kaspa-testnet",
+      "dogecoin-testnet",
+      "bitcoin-cash-testnet",
+      "zcash-testnet",
+      "dash",
+      "dash-testnet",
+      "lightning-testnet",
+      "ethereum-classic-mordor",
+      "hyperliquid-core-testnet",
+      "osmosis-testnet",
+      "celestia-testnet",
+      "dydx-testnet",
+      "injective-testnet",
+      "axelar-testnet",
+      "kava-testnet",
+      "persistence-testnet",
+      "archway-testnet",
+      "noble-testnet",
+      "neutron-testnet",
+      "coreum-testnet",
+      "mantra-testnet",
+      "babylon-testnet",
+      "urbit",
+      "berachain-testnet",
+      "ronin-testnet",
+      "oasis-testnet",
+      "core-testnet",
+      "monad-testnet",
+      "tezos",
+      "aleo",
+      "nano",
+      "chia",
+      "iota",
+    ]);
     for (const chain of CHAINS) {
       if (unverifiable.has(chain.id)) continue;
-      expect(chain.rpcUrls.length, `${chain.id} has no rpcUrls`).toBeGreaterThanOrEqual(1);
+      expect(
+        chain.rpcUrls.length,
+        `${chain.id} has no rpcUrls`,
+      ).toBeGreaterThanOrEqual(1);
     }
   });
 
   it("cosmos chains have bech32Prefix", () => {
-    const cosmosChains = CHAINS.filter((c) => c.family === "cosmos" && !c.isTestnet);
+    const cosmosChains = CHAINS.filter(
+      (c) => c.family === "cosmos" && !c.isTestnet,
+    );
     expect(cosmosChains.length).toBeGreaterThan(0);
     for (const chain of cosmosChains) {
-      expect(chain.bech32Prefix, `${chain.id} missing bech32Prefix`).toBeTruthy();
+      expect(
+        chain.bech32Prefix,
+        `${chain.id} missing bech32Prefix`,
+      ).toBeTruthy();
     }
   });
 
@@ -117,7 +176,9 @@ describe("CHAINS data integrity", () => {
   });
 
   it("no duplicate bech32 prefixes", () => {
-    const prefixes = CHAINS.filter((c) => c.bech32Prefix).map((c) => c.bech32Prefix!);
+    const prefixes = CHAINS.filter((c) => c.bech32Prefix).map(
+      (c) => c.bech32Prefix!,
+    );
     const unique = new Set(prefixes);
     expect(unique.size).toBe(prefixes.length);
   });

--- a/worker/src/chains.ts
+++ b/worker/src/chains.ts
@@ -108,14 +108,30 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Etherscan", baseUrl: "https://etherscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://eth.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Etherscan",
+        baseUrl: "https://etherscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://eth.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 1,
     alchemyNetwork: "eth-mainnet",
     coingeckoPlatformId: "ethereum",
     rpcUrls: [
-      { url: "https://eth-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://eth-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://ethereum-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -125,14 +141,30 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Basescan", baseUrl: "https://basescan.org", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://base.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Basescan",
+        baseUrl: "https://basescan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://base.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 8453,
     alchemyNetwork: "base-mainnet",
     coingeckoPlatformId: "base",
     rpcUrls: [
-      { url: "https://base-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://base-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://base-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -142,14 +174,30 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Arbiscan", baseUrl: "https://arbiscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://arbitrum.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Arbiscan",
+        baseUrl: "https://arbiscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://arbitrum.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 42161,
     alchemyNetwork: "arb-mainnet",
     coingeckoPlatformId: "arbitrum-one",
     rpcUrls: [
-      { url: "https://arb-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://arb-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://arbitrum-one-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -159,14 +207,30 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Optimistic Etherscan", baseUrl: "https://optimistic.etherscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://optimism.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Optimistic Etherscan",
+        baseUrl: "https://optimistic.etherscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://optimism.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 10,
     alchemyNetwork: "opt-mainnet",
     coingeckoPlatformId: "optimistic-ethereum",
     rpcUrls: [
-      { url: "https://opt-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://opt-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://optimism-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -176,14 +240,30 @@ export const CHAINS: Chain[] = [
     symbol: "POL",
     family: "evm",
     explorers: [
-      { name: "Polygonscan", baseUrl: "https://polygonscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://polygon.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Polygonscan",
+        baseUrl: "https://polygonscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://polygon.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 137,
     alchemyNetwork: "polygon-mainnet",
     coingeckoPlatformId: "polygon-pos",
     rpcUrls: [
-      { url: "https://polygon-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://polygon-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://polygon-bor-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -193,14 +273,30 @@ export const CHAINS: Chain[] = [
     symbol: "BNB",
     family: "evm",
     explorers: [
-      { name: "BscScan", baseUrl: "https://bscscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://bsc.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "BscScan",
+        baseUrl: "https://bscscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://bsc.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 56,
     alchemyNetwork: "bnb-mainnet",
     coingeckoPlatformId: "binance-smart-chain",
     rpcUrls: [
-      { url: "https://bnb-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://bnb-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://bsc-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -210,15 +306,34 @@ export const CHAINS: Chain[] = [
     symbol: "AVAX",
     family: "evm",
     explorers: [
-      { name: "Snowscan", baseUrl: "https://snowscan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://avalanche.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Snowscan",
+        baseUrl: "https://snowscan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://avalanche.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 43114,
     alchemyNetwork: "avax-mainnet",
     coingeckoPlatformId: "avalanche",
     rpcUrls: [
-      { url: "https://avax-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
-      { url: "https://avalanche-c-chain-rpc.publicnode.com", provider: "public" },
+      {
+        url: "https://avax-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
+      {
+        url: "https://avalanche-c-chain-rpc.publicnode.com",
+        provider: "public",
+      },
     ],
   },
   {
@@ -227,12 +342,16 @@ export const CHAINS: Chain[] = [
     symbol: "FTM",
     family: "evm",
     explorers: [
-      { name: "FtmScan", baseUrl: "https://ftmscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "FtmScan",
+        baseUrl: "https://ftmscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "fantom",
-    rpcUrls: [
-      { url: "https://rpcapi.fantom.network", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://rpcapi.fantom.network", provider: "public" }],
   },
   {
     id: "zksync",
@@ -240,13 +359,29 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "zkSync Explorer", baseUrl: "https://explorer.zksync.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://zksync.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "zkSync Explorer",
+        baseUrl: "https://explorer.zksync.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://zksync.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     alchemyNetwork: "zksync-mainnet",
     coingeckoPlatformId: "zksync",
     rpcUrls: [
-      { url: "https://zksync-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://zksync-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.era.zksync.io", provider: "public" },
     ],
   },
@@ -256,14 +391,30 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Lineascan", baseUrl: "https://lineascan.build", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://linea.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Lineascan",
+        baseUrl: "https://lineascan.build",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://linea.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 59144,
     alchemyNetwork: "linea-mainnet",
     coingeckoPlatformId: "linea",
     rpcUrls: [
-      { url: "https://linea-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://linea-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://linea-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -273,14 +424,30 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Scrollscan", baseUrl: "https://scrollscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://scroll.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Scrollscan",
+        baseUrl: "https://scrollscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://scroll.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 534352,
     alchemyNetwork: "scroll-mainnet",
     coingeckoPlatformId: "scroll",
     rpcUrls: [
-      { url: "https://scroll-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://scroll-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://scroll-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -290,14 +457,30 @@ export const CHAINS: Chain[] = [
     symbol: "MNT",
     family: "evm",
     explorers: [
-      { name: "Mantlescan", baseUrl: "https://mantlescan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Blockscout", baseUrl: "https://mantle.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Mantlescan",
+        baseUrl: "https://mantlescan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Blockscout",
+        baseUrl: "https://mantle.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 5000,
     alchemyNetwork: "mantle-mainnet",
     coingeckoPlatformId: "mantle",
     rpcUrls: [
-      { url: "https://mantle-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://mantle-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mantle-rpc.publicnode.com", provider: "public" },
     ],
   },
@@ -308,7 +491,13 @@ export const CHAINS: Chain[] = [
     symbol: "ETC",
     family: "evm",
     explorers: [
-      { name: "Blockscout", baseUrl: "https://etc.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Blockscout",
+        baseUrl: "https://etc.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://etc.blockscout.com/api/eth-rpc", provider: "public" },
@@ -321,10 +510,19 @@ export const CHAINS: Chain[] = [
     symbol: "HYPE",
     family: "evm",
     explorers: [
-      { name: "Hypurrscan", baseUrl: "https://hypurrscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Hypurrscan",
+        baseUrl: "https://hypurrscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://hyperliquid-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://hyperliquid-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.hyperliquid.xyz/evm", provider: "public" },
     ],
   },
@@ -334,11 +532,14 @@ export const CHAINS: Chain[] = [
     symbol: "HYPE",
     family: "evm",
     explorers: [
-      { name: "Hypurrscan", baseUrl: "https://hypurrscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Hypurrscan",
+        baseUrl: "https://hypurrscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.hyperliquid.xyz/info", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.hyperliquid.xyz/info", provider: "public" }],
   },
 
   {
@@ -347,10 +548,20 @@ export const CHAINS: Chain[] = [
     symbol: "BERA",
     family: "evm",
     explorers: [
-      { name: "Berascan", baseUrl: "https://berascan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Berascan",
+        baseUrl: "https://berascan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://berachain-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://berachain-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.berachain.com", provider: "public" },
     ],
   },
@@ -360,10 +571,19 @@ export const CHAINS: Chain[] = [
     symbol: "RON",
     family: "evm",
     explorers: [
-      { name: "Ronin Explorer", baseUrl: "https://app.roninchain.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Ronin Explorer",
+        baseUrl: "https://app.roninchain.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://ronin-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://ronin-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://api.roninchain.com/rpc", provider: "public" },
     ],
   },
@@ -373,11 +593,15 @@ export const CHAINS: Chain[] = [
     symbol: "FLR",
     family: "evm",
     explorers: [
-      { name: "Flarescan", baseUrl: "https://mainnet.flarescan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Flarescan",
+        baseUrl: "https://mainnet.flarescan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://rpc.ankr.com/flare", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://rpc.ankr.com/flare", provider: "public" }],
   },
   {
     id: "oasis-sapphire",
@@ -385,11 +609,14 @@ export const CHAINS: Chain[] = [
     symbol: "ROSE",
     family: "evm",
     explorers: [
-      { name: "Oasis Explorer", baseUrl: "https://explorer.oasis.io/mainnet/sapphire", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Oasis Explorer",
+        baseUrl: "https://explorer.oasis.io/mainnet/sapphire",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://sapphire.oasis.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://sapphire.oasis.io", provider: "public" }],
   },
   {
     id: "core",
@@ -397,11 +624,15 @@ export const CHAINS: Chain[] = [
     symbol: "CORE",
     family: "evm",
     explorers: [
-      { name: "Core Scan", baseUrl: "https://scan.coredao.org", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Core Scan",
+        baseUrl: "https://scan.coredao.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://rpc.coredao.org", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://rpc.coredao.org", provider: "public" }],
   },
   {
     id: "monad",
@@ -409,10 +640,20 @@ export const CHAINS: Chain[] = [
     symbol: "MON",
     family: "evm",
     explorers: [
-      { name: "MonadScan", baseUrl: "https://monadscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "MonadScan",
+        baseUrl: "https://monadscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://monad-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://monad-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.monad.xyz", provider: "public" },
     ],
   },
@@ -422,10 +663,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "MegaETH Explorer", baseUrl: "https://megaeth.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "MegaETH Explorer",
+        baseUrl: "https://megaeth.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://megaeth-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://megaeth-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.megaeth.com", provider: "public" },
     ],
   },
@@ -435,10 +686,19 @@ export const CHAINS: Chain[] = [
     symbol: "PLASMA",
     family: "evm",
     explorers: [
-      { name: "Plasma Scan", baseUrl: "https://plasmascan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Plasma Scan",
+        baseUrl: "https://plasmascan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://plasma-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://plasma-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.plasma.to", provider: "public" },
     ],
   },
@@ -450,11 +710,21 @@ export const CHAINS: Chain[] = [
     symbol: "xDAI",
     family: "evm",
     explorers: [
-      { name: "Gnosisscan", baseUrl: "https://gnosisscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Gnosisscan",
+        baseUrl: "https://gnosisscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "xdai",
     rpcUrls: [
-      { url: "https://gnosis-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://gnosis-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.gnosischain.com", provider: "public" },
     ],
   },
@@ -464,11 +734,21 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Blastscan", baseUrl: "https://blastscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Blastscan",
+        baseUrl: "https://blastscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "blast",
     rpcUrls: [
-      { url: "https://blast-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://blast-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.blast.io", provider: "public" },
     ],
   },
@@ -478,10 +758,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Worldscan", baseUrl: "https://worldscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Worldscan",
+        baseUrl: "https://worldscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://worldchain-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://worldchain-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -490,11 +780,21 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Zora Explorer", baseUrl: "https://explorer.zora.energy", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Zora Explorer",
+        baseUrl: "https://explorer.zora.energy",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "zora",
     rpcUrls: [
-      { url: "https://zora-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://zora-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.zora.energy", provider: "public" },
     ],
   },
@@ -504,10 +804,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Uniscan", baseUrl: "https://uniscan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Uniscan",
+        baseUrl: "https://uniscan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://unichain-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://unichain-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.unichain.org", provider: "public" },
     ],
   },
@@ -517,11 +827,21 @@ export const CHAINS: Chain[] = [
     symbol: "CELO",
     family: "evm",
     explorers: [
-      { name: "Celoscan", baseUrl: "https://celoscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Celoscan",
+        baseUrl: "https://celoscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "celo",
     rpcUrls: [
-      { url: "https://celo-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://celo-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://forno.celo.org", provider: "public" },
     ],
   },
@@ -531,11 +851,21 @@ export const CHAINS: Chain[] = [
     symbol: "METIS",
     family: "evm",
     explorers: [
-      { name: "Metis Explorer", baseUrl: "https://andromeda-explorer.metis.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Metis Explorer",
+        baseUrl: "https://andromeda-explorer.metis.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "metis-andromeda",
     rpcUrls: [
-      { url: "https://metis-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://metis-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://andromeda.metis.io/?owner=1088", provider: "public" },
     ],
   },
@@ -545,11 +875,21 @@ export const CHAINS: Chain[] = [
     symbol: "GLMR",
     family: "evm",
     explorers: [
-      { name: "Moonscan", baseUrl: "https://moonscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Moonscan",
+        baseUrl: "https://moonscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "moonbeam",
     rpcUrls: [
-      { url: "https://moonbeam-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://moonbeam-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.api.moonbeam.network", provider: "public" },
     ],
   },
@@ -559,10 +899,20 @@ export const CHAINS: Chain[] = [
     symbol: "APE",
     family: "evm",
     explorers: [
-      { name: "Apescan", baseUrl: "https://apescan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Apescan",
+        baseUrl: "https://apescan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://apechain-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://apechain-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.apechain.com/http", provider: "public" },
     ],
   },
@@ -572,11 +922,21 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Arbiscan Nova", baseUrl: "https://nova.arbiscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Arbiscan Nova",
+        baseUrl: "https://nova.arbiscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "arbitrum-nova",
     rpcUrls: [
-      { url: "https://arbnova-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://arbnova-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://nova.arbitrum.io/rpc", provider: "public" },
     ],
   },
@@ -586,11 +946,21 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Polygon zkEVM Scan", baseUrl: "https://zkevm.polygonscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Polygon zkEVM Scan",
+        baseUrl: "https://zkevm.polygonscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "polygon-zkevm",
     rpcUrls: [
-      { url: "https://polygonzkevm-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://polygonzkevm-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://zkevm-rpc.com", provider: "public" },
     ],
   },
@@ -600,11 +970,21 @@ export const CHAINS: Chain[] = [
     symbol: "BNB",
     family: "evm",
     explorers: [
-      { name: "opBNBscan", baseUrl: "https://opbnbscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "opBNBscan",
+        baseUrl: "https://opbnbscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "opbnb",
     rpcUrls: [
-      { url: "https://opbnb-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://opbnb-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://opbnb-mainnet-rpc.bnbchain.org", provider: "public" },
     ],
   },
@@ -614,11 +994,21 @@ export const CHAINS: Chain[] = [
     symbol: "S",
     family: "evm",
     explorers: [
-      { name: "Sonicscan", baseUrl: "https://sonicscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Sonicscan",
+        baseUrl: "https://sonicscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "sonic",
     rpcUrls: [
-      { url: "https://sonic-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://sonic-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.soniclabs.com", provider: "public" },
     ],
   },
@@ -628,10 +1018,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Abscan", baseUrl: "https://abscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Abscan",
+        baseUrl: "https://abscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://abstract-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://abstract-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://api.abstractions.zone", provider: "public" },
     ],
   },
@@ -641,10 +1041,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Soneium Explorer", baseUrl: "https://soneium.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Soneium Explorer",
+        baseUrl: "https://soneium.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://soneium-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://soneium-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.soneium.org", provider: "public" },
     ],
   },
@@ -654,11 +1064,21 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Modescan", baseUrl: "https://modescan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Modescan",
+        baseUrl: "https://modescan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "mode",
     rpcUrls: [
-      { url: "https://mode-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://mode-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.mode.network", provider: "public" },
     ],
   },
@@ -668,11 +1088,21 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Bobascan", baseUrl: "https://bobascan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Bobascan",
+        baseUrl: "https://bobascan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "boba",
     rpcUrls: [
-      { url: "https://boba-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://boba-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.boba.network", provider: "public" },
     ],
   },
@@ -682,10 +1112,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "BOB Explorer", baseUrl: "https://explorer.gobob.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "BOB Explorer",
+        baseUrl: "https://explorer.gobob.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://bob-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://bob-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.gobob.xyz", provider: "public" },
     ],
   },
@@ -695,12 +1135,25 @@ export const CHAINS: Chain[] = [
     symbol: "ZETA",
     family: "evm",
     explorers: [
-      { name: "ZetaChain Explorer", baseUrl: "https://explorer.zetachain.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "ZetaChain Explorer",
+        baseUrl: "https://explorer.zetachain.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "zetachain",
     rpcUrls: [
-      { url: "https://zetachain-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
-      { url: "https://zetachain-evm.blockpi.network/v1/rpc/public", provider: "public" },
+      {
+        url: "https://zetachain-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
+      {
+        url: "https://zetachain-evm.blockpi.network/v1/rpc/public",
+        provider: "public",
+      },
     ],
   },
   {
@@ -709,11 +1162,21 @@ export const CHAINS: Chain[] = [
     symbol: "frxETH",
     family: "evm",
     explorers: [
-      { name: "Fraxscan", baseUrl: "https://fraxscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Fraxscan",
+        baseUrl: "https://fraxscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "fraxtal",
     rpcUrls: [
-      { url: "https://frax-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://frax-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.frax.com", provider: "public" },
     ],
   },
@@ -723,11 +1186,21 @@ export const CHAINS: Chain[] = [
     symbol: "RBTC",
     family: "evm",
     explorers: [
-      { name: "Rootstock Explorer", baseUrl: "https://rootstock.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Rootstock Explorer",
+        baseUrl: "https://rootstock.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "rootstock",
     rpcUrls: [
-      { url: "https://rootstock-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://rootstock-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://public-node.rsk.co", provider: "public" },
     ],
   },
@@ -737,10 +1210,20 @@ export const CHAINS: Chain[] = [
     symbol: "FLOW",
     family: "evm",
     explorers: [
-      { name: "Flowscan EVM", baseUrl: "https://evm.flowscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Flowscan EVM",
+        baseUrl: "https://evm.flowscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://flow-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://flow-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.evm.nodes.onflow.org", provider: "public" },
     ],
   },
@@ -750,11 +1233,21 @@ export const CHAINS: Chain[] = [
     symbol: "ASTR",
     family: "evm",
     explorers: [
-      { name: "Astar Explorer", baseUrl: "https://astar.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Astar Explorer",
+        baseUrl: "https://astar.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     coingeckoPlatformId: "astar",
     rpcUrls: [
-      { url: "https://astar-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://astar-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://evm.astar.network", provider: "public" },
     ],
   },
@@ -764,10 +1257,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Ink Explorer", baseUrl: "https://explorer.inkonchain.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Ink Explorer",
+        baseUrl: "https://explorer.inkonchain.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://ink-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://ink-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc-gel.inkonchain.com", provider: "public" },
     ],
   },
@@ -777,10 +1280,20 @@ export const CHAINS: Chain[] = [
     symbol: "DEGEN",
     family: "evm",
     explorers: [
-      { name: "Degen Explorer", baseUrl: "https://explorer.degen.tips", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Degen Explorer",
+        baseUrl: "https://explorer.degen.tips",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://degen-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://degen-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.degen.tips", provider: "public" },
     ],
   },
@@ -790,10 +1303,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Shapescan", baseUrl: "https://shapescan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Shapescan",
+        baseUrl: "https://shapescan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://shape-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://shape-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.shape.network", provider: "public" },
     ],
   },
@@ -803,10 +1326,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Superseed Explorer", baseUrl: "https://explorer.superseed.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Superseed Explorer",
+        baseUrl: "https://explorer.superseed.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://superseed-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://superseed-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.superseed.xyz", provider: "public" },
     ],
   },
@@ -816,10 +1349,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Polynomialscan", baseUrl: "https://polynomialscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Polynomialscan",
+        baseUrl: "https://polynomialscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://polynomial-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://polynomial-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.polynomial.fi", provider: "public" },
     ],
   },
@@ -829,10 +1372,20 @@ export const CHAINS: Chain[] = [
     symbol: "IP",
     family: "evm",
     explorers: [
-      { name: "Storyscan", baseUrl: "https://www.storyscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Storyscan",
+        baseUrl: "https://www.storyscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://story-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://story-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://mainnet.storyrpc.io", provider: "public" },
     ],
   },
@@ -842,10 +1395,20 @@ export const CHAINS: Chain[] = [
     symbol: "GHO",
     family: "evm",
     explorers: [
-      { name: "Lens Explorer", baseUrl: "https://explorer.lens.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Lens Explorer",
+        baseUrl: "https://explorer.lens.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://lens-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://lens-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.lens.xyz", provider: "public" },
     ],
   },
@@ -855,10 +1418,20 @@ export const CHAINS: Chain[] = [
     symbol: "ANIME",
     family: "evm",
     explorers: [
-      { name: "Anime Explorer", baseUrl: "https://explorer.anime.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Anime Explorer",
+        baseUrl: "https://explorer.anime.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://anime-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://anime-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.anime.xyz", provider: "public" },
     ],
   },
@@ -868,10 +1441,20 @@ export const CHAINS: Chain[] = [
     symbol: "cBTC",
     family: "evm",
     explorers: [
-      { name: "Citrea Explorer", baseUrl: "https://explorer.mainnet.citrea.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Citrea Explorer",
+        baseUrl: "https://explorer.mainnet.citrea.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://citrea-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://citrea-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.citrea.xyz", provider: "public" },
     ],
   },
@@ -881,10 +1464,20 @@ export const CHAINS: Chain[] = [
     symbol: "BTC",
     family: "evm",
     explorers: [
-      { name: "Botanixscan", baseUrl: "https://botanixscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Botanixscan",
+        baseUrl: "https://botanixscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://botanix-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://botanix-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.botanixlabs.dev", provider: "public" },
     ],
   },
@@ -894,10 +1487,19 @@ export const CHAINS: Chain[] = [
     symbol: "XFI",
     family: "evm",
     explorers: [
-      { name: "XFIscan", baseUrl: "https://xfiscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "XFIscan",
+        baseUrl: "https://xfiscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://crossfi-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://crossfi-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -906,10 +1508,20 @@ export const CHAINS: Chain[] = [
     symbol: "GNET",
     family: "evm",
     explorers: [
-      { name: "Galactica Explorer", baseUrl: "https://explorer.galactica.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Galactica Explorer",
+        baseUrl: "https://explorer.galactica.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://galactica-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://galactica-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://evm-rpc-http.galactica.com", provider: "public" },
     ],
   },
@@ -919,10 +1531,20 @@ export const CHAINS: Chain[] = [
     symbol: "RWT",
     family: "evm",
     explorers: [
-      { name: "Humanity Explorer", baseUrl: "https://humanity-mainnet.explorer.alchemy.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Humanity Explorer",
+        baseUrl: "https://humanity-mainnet.explorer.alchemy.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://humanity-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://humanity-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://rpc.humanity.org", provider: "public" },
     ],
   },
@@ -932,10 +1554,20 @@ export const CHAINS: Chain[] = [
     symbol: "USDT",
     family: "evm",
     explorers: [
-      { name: "Stablescan", baseUrl: "https://stablescan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Stablescan",
+        baseUrl: "https://stablescan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://stable-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://stable-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -944,10 +1576,20 @@ export const CHAINS: Chain[] = [
     symbol: "MYTH",
     family: "evm",
     explorers: [
-      { name: "Mythos Explorer", baseUrl: "https://mythos-mainnet.explorer.alchemy.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Mythos Explorer",
+        baseUrl: "https://mythos-mainnet.explorer.alchemy.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://mythos-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://mythos-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -956,10 +1598,20 @@ export const CHAINS: Chain[] = [
     symbol: "SETL",
     family: "evm",
     explorers: [
-      { name: "Settlus Explorer", baseUrl: "https://mainnet.settlus.network", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Settlus Explorer",
+        baseUrl: "https://mainnet.settlus.network",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://settlus-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://settlus-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -968,10 +1620,20 @@ export const CHAINS: Chain[] = [
     symbol: "ETH",
     family: "evm",
     explorers: [
-      { name: "Syndicate Explorer", baseUrl: "https://explorer.syndicate.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Syndicate Explorer",
+        baseUrl: "https://explorer.syndicate.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://synd-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://synd-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -980,10 +1642,20 @@ export const CHAINS: Chain[] = [
     symbol: "WMT",
     family: "evm",
     explorers: [
-      { name: "World Mobile Explorer", baseUrl: "https://explorer.worldmobile.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "World Mobile Explorer",
+        baseUrl: "https://explorer.worldmobile.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://worldmobilechain-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://worldmobilechain-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -992,10 +1664,20 @@ export const CHAINS: Chain[] = [
     symbol: "ADI",
     family: "evm",
     explorers: [
-      { name: "ADI Explorer", baseUrl: "https://explorer-bls.adifoundation.ai", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "ADI Explorer",
+        baseUrl: "https://explorer-bls.adifoundation.ai",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://adi-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://adi-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
 
@@ -1006,12 +1688,20 @@ export const CHAINS: Chain[] = [
     symbol: "BTC",
     family: "bitcoin",
     explorers: [
-      { name: "mempool.space", baseUrl: "https://mempool.space", addressPath: "/address/{query}", txPath: "/tx/{query}" },
-      { name: "Blockstream", baseUrl: "https://blockstream.info", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "mempool.space",
+        baseUrl: "https://mempool.space",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
+      {
+        name: "Blockstream",
+        baseUrl: "https://blockstream.info",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://mempool.space/api", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://mempool.space/api", provider: "public" }],
   },
   {
     id: "solana",
@@ -1019,14 +1709,38 @@ export const CHAINS: Chain[] = [
     symbol: "SOL",
     family: "solana",
     explorers: [
-      { name: "Solscan", baseUrl: "https://solscan.io", addressPath: "/account/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
-      { name: "Solana Explorer", baseUrl: "https://explorer.solana.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
-      { name: "SolanaFM", baseUrl: "https://solana.fm", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Solscan",
+        baseUrl: "https://solscan.io",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
+      {
+        name: "Solana Explorer",
+        baseUrl: "https://explorer.solana.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
+      {
+        name: "SolanaFM",
+        baseUrl: "https://solana.fm",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     coingeckoPlatformId: "solana",
     rpcUrls: [
-      { url: "https://mainnet.helius-rpc.com/?api-key={key}", provider: "helius", keyEnvVar: "HELIUS_API_KEY" },
-      { url: "https://solana-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://mainnet.helius-rpc.com/?api-key={key}",
+        provider: "helius",
+        keyEnvVar: "HELIUS_API_KEY",
+      },
+      {
+        url: "https://solana-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://api.mainnet-beta.solana.com", provider: "public" },
     ],
   },
@@ -1036,7 +1750,12 @@ export const CHAINS: Chain[] = [
     symbol: "DOGE",
     family: "dogecoin",
     explorers: [
-      { name: "Blockchair", baseUrl: "https://blockchair.com/dogecoin", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
+      {
+        name: "Blockchair",
+        baseUrl: "https://blockchair.com/dogecoin",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://api.blockcypher.com/v1/doge/main", provider: "public" },
@@ -1048,7 +1767,12 @@ export const CHAINS: Chain[] = [
     symbol: "LTC",
     family: "litecoin",
     explorers: [
-      { name: "Blockchair", baseUrl: "https://blockchair.com/litecoin", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
+      {
+        name: "Blockchair",
+        baseUrl: "https://blockchair.com/litecoin",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://api.blockcypher.com/v1/ltc/main", provider: "public" },
@@ -1060,7 +1784,12 @@ export const CHAINS: Chain[] = [
     symbol: "BCH",
     family: "bitcoincash",
     explorers: [
-      { name: "Blockchair", baseUrl: "https://blockchair.com/bitcoin-cash", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
+      {
+        name: "Blockchair",
+        baseUrl: "https://blockchair.com/bitcoin-cash",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://api.blockchair.com/bitcoin-cash", provider: "public" },
@@ -1072,11 +1801,14 @@ export const CHAINS: Chain[] = [
     symbol: "ZEC",
     family: "zcash",
     explorers: [
-      { name: "Blockchair", baseUrl: "https://blockchair.com/zcash", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
+      {
+        name: "Blockchair",
+        baseUrl: "https://blockchair.com/zcash",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.blockchair.com/zcash", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.blockchair.com/zcash", provider: "public" }],
   },
 
   {
@@ -1085,7 +1817,12 @@ export const CHAINS: Chain[] = [
     symbol: "DASH",
     family: "dash",
     explorers: [
-      { name: "BlockExplorer.one", baseUrl: "https://blockexplorer.one/dash/mainnet", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BlockExplorer.one",
+        baseUrl: "https://blockexplorer.one/dash/mainnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -1096,8 +1833,18 @@ export const CHAINS: Chain[] = [
     symbol: "URBIT",
     family: "urbit",
     explorers: [
-      { name: "Network Explorer", baseUrl: "https://network.urbit.org", addressPath: "/{query}", txPath: "" },
-      { name: "Urbit Live", baseUrl: "https://urbit.live", addressPath: "/{query}", txPath: "" },
+      {
+        name: "Network Explorer",
+        baseUrl: "https://network.urbit.org",
+        addressPath: "/{query}",
+        txPath: "",
+      },
+      {
+        name: "Urbit Live",
+        baseUrl: "https://urbit.live",
+        addressPath: "/{query}",
+        txPath: "",
+      },
     ],
     rpcUrls: [],
   },
@@ -1108,12 +1855,20 @@ export const CHAINS: Chain[] = [
     symbol: "XTZ",
     family: "tezos",
     explorers: [
-      { name: "TzKT", baseUrl: "https://tzkt.io", addressPath: "/{query}", txPath: "/{query}" },
-      { name: "TzStats", baseUrl: "https://tzstats.com", addressPath: "/{query}", txPath: "/{query}" },
+      {
+        name: "TzKT",
+        baseUrl: "https://tzkt.io",
+        addressPath: "/{query}",
+        txPath: "/{query}",
+      },
+      {
+        name: "TzStats",
+        baseUrl: "https://tzstats.com",
+        addressPath: "/{query}",
+        txPath: "/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://mainnet.api.tez.ie", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://mainnet.api.tez.ie", provider: "public" }],
   },
   {
     id: "aleo",
@@ -1121,8 +1876,18 @@ export const CHAINS: Chain[] = [
     symbol: "ALEO",
     family: "aleo",
     explorers: [
-      { name: "Aleo Explorer", baseUrl: "https://explorer.aleo.org", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
-      { name: "AleoScan", baseUrl: "https://aleoscan.io", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
+      {
+        name: "Aleo Explorer",
+        baseUrl: "https://explorer.aleo.org",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
+      {
+        name: "AleoScan",
+        baseUrl: "https://aleoscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -1132,8 +1897,18 @@ export const CHAINS: Chain[] = [
     symbol: "XNO",
     family: "nano",
     explorers: [
-      { name: "NanoCrawler", baseUrl: "https://nanocrawler.cc", addressPath: "/explorer/account/{query}", txPath: "/explorer/block/{query}" },
-      { name: "Nanexplorer", baseUrl: "https://nanexplorer.com", addressPath: "/accounts/{query}", txPath: "/blocks/{query}" },
+      {
+        name: "NanoCrawler",
+        baseUrl: "https://nanocrawler.cc",
+        addressPath: "/explorer/account/{query}",
+        txPath: "/explorer/block/{query}",
+      },
+      {
+        name: "Nanexplorer",
+        baseUrl: "https://nanexplorer.com",
+        addressPath: "/accounts/{query}",
+        txPath: "/blocks/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -1143,8 +1918,18 @@ export const CHAINS: Chain[] = [
     symbol: "XCH",
     family: "chia",
     explorers: [
-      { name: "XCHscan", baseUrl: "https://xchscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
-      { name: "Spacescan", baseUrl: "https://www.spacescan.io", addressPath: "/address/{query}", txPath: "/coin/{query}" },
+      {
+        name: "XCHscan",
+        baseUrl: "https://xchscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
+      {
+        name: "Spacescan",
+        baseUrl: "https://www.spacescan.io",
+        addressPath: "/address/{query}",
+        txPath: "/coin/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -1155,11 +1940,14 @@ export const CHAINS: Chain[] = [
     symbol: "NOCK",
     family: "nockchain",
     explorers: [
-      { name: "NockBlocks", baseUrl: "https://nockblocks.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "NockBlocks",
+        baseUrl: "https://nockblocks.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://nockblocks.com/rpc/v1", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://nockblocks.com/rpc/v1", provider: "public" }],
   },
 
   {
@@ -1168,11 +1956,14 @@ export const CHAINS: Chain[] = [
     symbol: "STX",
     family: "stacks",
     explorers: [
-      { name: "Hiro Explorer", baseUrl: "https://explorer.hiro.so", addressPath: "/address/{query}?chain=mainnet", txPath: "/txid/{query}?chain=mainnet" },
+      {
+        name: "Hiro Explorer",
+        baseUrl: "https://explorer.hiro.so",
+        addressPath: "/address/{query}?chain=mainnet",
+        txPath: "/txid/{query}?chain=mainnet",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.mainnet.hiro.so", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.mainnet.hiro.so", provider: "public" }],
   },
 
   // --- Cosmos Chains ---
@@ -1183,7 +1974,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "cosmos",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/cosmos", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/cosmos",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://cosmos-rest.publicnode.com", provider: "public" },
@@ -1196,7 +1994,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "osmo",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/osmosis", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/osmosis",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://osmosis-rest.publicnode.com", provider: "public" },
@@ -1209,8 +2014,20 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "celestia",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/celestia", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
-      { name: "Celenium", baseUrl: "https://celenium.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/celestia",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
+      {
+        name: "Celenium",
+        baseUrl: "https://celenium.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://celestia-rest.publicnode.com", provider: "public" },
@@ -1223,11 +2040,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "dydx",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/dydx", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/dydx",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://dydx-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://dydx-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "injective",
@@ -1236,7 +2058,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "inj",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/injective", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/injective",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://injective-rest.publicnode.com", provider: "public" },
@@ -1249,11 +2078,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "sei",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/sei", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/sei",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://sei-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://sei-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "stride",
@@ -1262,7 +2096,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "stride",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/stride", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/stride",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://stride-rest.publicnode.com", provider: "public" },
@@ -1275,7 +2116,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "stars",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/stargaze", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/stargaze",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://stargaze-rest.publicnode.com", provider: "public" },
@@ -1288,11 +2136,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "akash",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/akash", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/akash",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://akash-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://akash-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "axelar",
@@ -1301,7 +2154,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "axelar",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/axelar", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/axelar",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://axelar-rest.publicnode.com", provider: "public" },
@@ -1314,11 +2174,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "kava",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/kava", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/kava",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://kava-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://kava-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "juno",
@@ -1327,11 +2192,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "juno",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/juno", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/juno",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://juno-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://juno-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "evmos",
@@ -1340,11 +2210,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "evmos",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/evmos", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/evmos",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://evmos-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://evmos-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "secret",
@@ -1353,10 +2228,20 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "secret",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/secret", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/secret",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://rest.lavenderfive.com:443/secretnetwork", provider: "public" },
+      {
+        url: "https://rest.lavenderfive.com:443/secretnetwork",
+        provider: "public",
+      },
     ],
   },
   {
@@ -1366,11 +2251,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "band",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/band", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/band",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://laozi1.bandchain.org/api", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://laozi1.bandchain.org/api", provider: "public" }],
   },
   {
     id: "persistence",
@@ -1379,7 +2269,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "persistence",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/persistence", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/persistence",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://persistence-rest.publicnode.com", provider: "public" },
@@ -1392,11 +2289,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "fetch",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/fetchai", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/fetchai",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://fetch-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://fetch-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "regen",
@@ -1405,11 +2307,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "regen",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/regen", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/regen",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://regen-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://regen-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "sentinel",
@@ -1418,7 +2325,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "sent",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/sentinel", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/sentinel",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://sentinel-rest.publicnode.com", provider: "public" },
@@ -1431,7 +2345,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "somm",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/sommelier", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/sommelier",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://api-sommelier.pupmos.network", provider: "public" },
@@ -1444,7 +2365,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "chihuahua",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/chihuahua", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/chihuahua",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://chihuahua-rest.publicnode.com", provider: "public" },
@@ -1457,11 +2385,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "archway",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/archway", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/archway",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.mainnet.archway.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.mainnet.archway.io", provider: "public" }],
   },
   {
     id: "noble",
@@ -1470,11 +2403,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "noble",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/noble", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/noble",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://noble-api.polkachu.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://noble-api.polkachu.com", provider: "public" }],
   },
   {
     id: "neutron",
@@ -1483,7 +2421,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "neutron",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/neutron", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/neutron",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://neutron-rest.publicnode.com", provider: "public" },
@@ -1496,7 +2441,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "core",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/coreum", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/coreum",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://coreum-rest.publicnode.com", provider: "public" },
@@ -1509,11 +2461,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "kyve",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/kyve", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/kyve",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.kyve.network", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.kyve.network", provider: "public" }],
   },
   {
     id: "agoric",
@@ -1522,11 +2479,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "agoric",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/agoric", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/agoric",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://main.api.agoric.net:443", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://main.api.agoric.net:443", provider: "public" }],
   },
   {
     id: "omniflix",
@@ -1535,7 +2497,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "omniflix",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/omniflix", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/omniflix",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://api.omniflix.nodestake.org", provider: "public" },
@@ -1548,11 +2517,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "terra",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/terra", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/terra",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://terra-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://terra-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "gravity-bridge",
@@ -1561,11 +2535,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "gravity",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/gravity-bridge", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/gravity-bridge",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://gravitychain.io:1317", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://gravitychain.io:1317", provider: "public" }],
   },
   {
     id: "iris",
@@ -1574,11 +2553,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "iaa",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/iris", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/iris",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://iris-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://iris-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "crypto-org",
@@ -1587,11 +2571,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "cro",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/crypto-org", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/crypto-org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://rest.mainnet.crypto.org", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://rest.mainnet.crypto.org", provider: "public" }],
   },
   {
     id: "dymension",
@@ -1600,7 +2589,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "dym",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/dymension", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/dymension",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://dymension-rest.publicnode.com", provider: "public" },
@@ -1613,11 +2609,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "mantra",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/mantra", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/mantra",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.mantrachain.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.mantrachain.io", provider: "public" }],
   },
   {
     id: "babylon",
@@ -1626,7 +2627,14 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "bbn",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/babylon", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/babylon",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://babylon-rest.publicnode.com", provider: "public" },
@@ -1639,11 +2647,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "nolus",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/nolus", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/nolus",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://nolus-rest.publicnode.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://nolus-rest.publicnode.com", provider: "public" }],
   },
   {
     id: "pryzm",
@@ -1652,11 +2665,16 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "pryzm",
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/pryzm", addressPath: "/address/{query}", txPath: "/tx/{query}", denomPath: "/assets/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/pryzm",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        denomPath: "/assets/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.pryzm.zone", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.pryzm.zone", provider: "public" }],
   },
   {
     id: "thorchain",
@@ -1665,12 +2683,20 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     bech32Prefix: "thor",
     explorers: [
-      { name: "RuneScan", baseUrl: "https://runescan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
-      { name: "ViewBlock", baseUrl: "https://viewblock.io/thorchain", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "RuneScan",
+        baseUrl: "https://runescan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
+      {
+        name: "ViewBlock",
+        baseUrl: "https://viewblock.io/thorchain",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://thornode.ninerealms.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://thornode.ninerealms.com", provider: "public" }],
   },
   {
     id: "sui",
@@ -1678,11 +2704,25 @@ export const CHAINS: Chain[] = [
     symbol: "SUI",
     family: "sui",
     explorers: [
-      { name: "Suiscan", baseUrl: "https://suiscan.xyz", addressPath: "/account/{query}", txPath: "/tx/{query}" },
-      { name: "Sui Explorer", baseUrl: "https://suiexplorer.com", addressPath: "/address/{query}", txPath: "/txblock/{query}" },
+      {
+        name: "Suiscan",
+        baseUrl: "https://suiscan.xyz",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
+      {
+        name: "Sui Explorer",
+        baseUrl: "https://suiexplorer.com",
+        addressPath: "/address/{query}",
+        txPath: "/txblock/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://sui-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://sui-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://fullnode.mainnet.sui.io", provider: "public" },
     ],
   },
@@ -1692,11 +2732,25 @@ export const CHAINS: Chain[] = [
     symbol: "APT",
     family: "aptos",
     explorers: [
-      { name: "Aptos Explorer", baseUrl: "https://explorer.aptoslabs.com", addressPath: "/account/{query}", txPath: "/txn/{query}" },
-      { name: "Apscan", baseUrl: "https://apscan.io", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Aptos Explorer",
+        baseUrl: "https://explorer.aptoslabs.com",
+        addressPath: "/account/{query}",
+        txPath: "/txn/{query}",
+      },
+      {
+        name: "Apscan",
+        baseUrl: "https://apscan.io",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://aptos-mainnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://aptos-mainnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
       { url: "https://fullnode.mainnet.aptoslabs.com/v1", provider: "public" },
     ],
   },
@@ -1706,7 +2760,12 @@ export const CHAINS: Chain[] = [
     symbol: "MOVE",
     family: "aptos",
     explorers: [
-      { name: "Movement Explorer", baseUrl: "https://explorer.movementnetwork.xyz", addressPath: "/account/{query}?network=mainnet", txPath: "/txn/{query}?network=mainnet" },
+      {
+        name: "Movement Explorer",
+        baseUrl: "https://explorer.movementnetwork.xyz",
+        addressPath: "/account/{query}?network=mainnet",
+        txPath: "/txn/{query}?network=mainnet",
+      },
     ],
     rpcUrls: [
       { url: "https://mainnet.movementnetwork.xyz/v1", provider: "public" },
@@ -1718,11 +2777,14 @@ export const CHAINS: Chain[] = [
     symbol: "IOTA",
     family: "iota",
     explorers: [
-      { name: "IOTA Explorer", baseUrl: "https://explorer.iota.org", addressPath: "/address/{query}", txPath: "/txblock/{query}" },
+      {
+        name: "IOTA Explorer",
+        baseUrl: "https://explorer.iota.org",
+        addressPath: "/address/{query}",
+        txPath: "/txblock/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.mainnet.iota.cafe", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.mainnet.iota.cafe", provider: "public" }],
   },
   {
     id: "tron",
@@ -1730,11 +2792,14 @@ export const CHAINS: Chain[] = [
     symbol: "TRX",
     family: "tron",
     explorers: [
-      { name: "Tronscan", baseUrl: "https://tronscan.org", addressPath: "/#/address/{query}", txPath: "/#/transaction/{query}" },
+      {
+        name: "Tronscan",
+        baseUrl: "https://tronscan.org",
+        addressPath: "/#/address/{query}",
+        txPath: "/#/transaction/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.trongrid.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.trongrid.io", provider: "public" }],
   },
   {
     id: "ton",
@@ -1742,12 +2807,20 @@ export const CHAINS: Chain[] = [
     symbol: "TON",
     family: "ton",
     explorers: [
-      { name: "TON Viewer", baseUrl: "https://tonviewer.com", addressPath: "/{query}", txPath: "/transaction/{query}" },
-      { name: "Tonscan", baseUrl: "https://tonscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "TON Viewer",
+        baseUrl: "https://tonviewer.com",
+        addressPath: "/{query}",
+        txPath: "/transaction/{query}",
+      },
+      {
+        name: "Tonscan",
+        baseUrl: "https://tonscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://toncenter.com/api/v2", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://toncenter.com/api/v2", provider: "public" }],
   },
   {
     id: "polkadot",
@@ -1755,7 +2828,12 @@ export const CHAINS: Chain[] = [
     symbol: "DOT",
     family: "polkadot",
     explorers: [
-      { name: "Subscan", baseUrl: "https://polkadot.subscan.io", addressPath: "/account/{query}", txPath: "/extrinsic/{query}" },
+      {
+        name: "Subscan",
+        baseUrl: "https://polkadot.subscan.io",
+        addressPath: "/account/{query}",
+        txPath: "/extrinsic/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://polkadot-rpc.publicnode.com", provider: "public" },
@@ -1767,12 +2845,20 @@ export const CHAINS: Chain[] = [
     symbol: "NEAR",
     family: "near",
     explorers: [
-      { name: "NearBlocks", baseUrl: "https://nearblocks.io", addressPath: "/address/{query}", txPath: "/txns/{query}" },
-      { name: "NEAR Explorer", baseUrl: "https://explorer.near.org", addressPath: "/accounts/{query}", txPath: "/transactions/{query}" },
+      {
+        name: "NearBlocks",
+        baseUrl: "https://nearblocks.io",
+        addressPath: "/address/{query}",
+        txPath: "/txns/{query}",
+      },
+      {
+        name: "NEAR Explorer",
+        baseUrl: "https://explorer.near.org",
+        addressPath: "/accounts/{query}",
+        txPath: "/transactions/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://rpc.mainnet.near.org", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://rpc.mainnet.near.org", provider: "public" }],
   },
   {
     id: "monero",
@@ -1780,7 +2866,12 @@ export const CHAINS: Chain[] = [
     symbol: "XMR",
     family: "monero",
     explorers: [
-      { name: "xmrchain.net", baseUrl: "https://xmrchain.net", addressPath: "/search?value={query}", txPath: "/tx/{query}" },
+      {
+        name: "xmrchain.net",
+        baseUrl: "https://xmrchain.net",
+        addressPath: "/search?value={query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -1790,11 +2881,14 @@ export const CHAINS: Chain[] = [
     symbol: "XRP",
     family: "xrp",
     explorers: [
-      { name: "XRPScan", baseUrl: "https://xrpscan.com", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "XRPScan",
+        baseUrl: "https://xrpscan.com",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://s1.ripple.com:51234/", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://s1.ripple.com:51234/", provider: "public" }],
   },
   {
     id: "stellar",
@@ -1802,11 +2896,14 @@ export const CHAINS: Chain[] = [
     symbol: "XLM",
     family: "stellar",
     explorers: [
-      { name: "StellarExpert", baseUrl: "https://stellar.expert/explorer/public", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "StellarExpert",
+        baseUrl: "https://stellar.expert/explorer/public",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://horizon.stellar.org", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://horizon.stellar.org", provider: "public" }],
   },
   {
     id: "bittensor",
@@ -1814,7 +2911,12 @@ export const CHAINS: Chain[] = [
     symbol: "TAO",
     family: "bittensor",
     explorers: [
-      { name: "Taostats", baseUrl: "https://taostats.io", addressPath: "/account/{query}", txPath: "/extrinsic/{query}" },
+      {
+        name: "Taostats",
+        baseUrl: "https://taostats.io",
+        addressPath: "/account/{query}",
+        txPath: "/extrinsic/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -1824,11 +2926,14 @@ export const CHAINS: Chain[] = [
     symbol: "ADA",
     family: "cardano",
     explorers: [
-      { name: "Cardanoscan", baseUrl: "https://cardanoscan.io", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
+      {
+        name: "Cardanoscan",
+        baseUrl: "https://cardanoscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.koios.rest/api/v1", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.koios.rest/api/v1", provider: "public" }],
   },
   {
     id: "lightning",
@@ -1836,8 +2941,18 @@ export const CHAINS: Chain[] = [
     symbol: "BTC",
     family: "lightning",
     explorers: [
-      { name: "mempool.space", baseUrl: "https://mempool.space", addressPath: "/lightning/node/{query}", txPath: "" },
-      { name: "Amboss", baseUrl: "https://amboss.space", addressPath: "/node/{query}", txPath: "" },
+      {
+        name: "mempool.space",
+        baseUrl: "https://mempool.space",
+        addressPath: "/lightning/node/{query}",
+        txPath: "",
+      },
+      {
+        name: "Amboss",
+        baseUrl: "https://amboss.space",
+        addressPath: "/node/{query}",
+        txPath: "",
+      },
     ],
     rpcUrls: [
       { url: "https://mempool.space/api/v1/lightning", provider: "public" },
@@ -1849,11 +2964,14 @@ export const CHAINS: Chain[] = [
     symbol: "FIL",
     family: "filecoin",
     explorers: [
-      { name: "Filfox", baseUrl: "https://filfox.info", addressPath: "/en/address/{query}", txPath: "/en/message/{query}" },
+      {
+        name: "Filfox",
+        baseUrl: "https://filfox.info",
+        addressPath: "/en/address/{query}",
+        txPath: "/en/message/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.node.glif.io/rpc/v1", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.node.glif.io/rpc/v1", provider: "public" }],
   },
   {
     id: "hedera",
@@ -1861,7 +2979,12 @@ export const CHAINS: Chain[] = [
     symbol: "HBAR",
     family: "hedera",
     explorers: [
-      { name: "HashScan", baseUrl: "https://hashscan.io", addressPath: "/mainnet/account/{query}", txPath: "/mainnet/transaction/{query}" },
+      {
+        name: "HashScan",
+        baseUrl: "https://hashscan.io",
+        addressPath: "/mainnet/account/{query}",
+        txPath: "/mainnet/transaction/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://mainnet.mirrornode.hedera.com", provider: "public" },
@@ -1873,11 +2996,14 @@ export const CHAINS: Chain[] = [
     symbol: "KAS",
     family: "kaspa",
     explorers: [
-      { name: "Kaspa Explorer", baseUrl: "https://explorer.kaspa.org", addressPath: "/addresses/{query}", txPath: "/txs/{query}" },
+      {
+        name: "Kaspa Explorer",
+        baseUrl: "https://explorer.kaspa.org",
+        addressPath: "/addresses/{query}",
+        txPath: "/txs/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.kaspa.org", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.kaspa.org", provider: "public" }],
   },
   {
     id: "algorand",
@@ -1885,7 +3011,12 @@ export const CHAINS: Chain[] = [
     symbol: "ALGO",
     family: "algorand",
     explorers: [
-      { name: "Allo.info", baseUrl: "https://allo.info", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Allo.info",
+        baseUrl: "https://allo.info",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://mainnet-idx.algonode.cloud", provider: "public" },
@@ -1897,11 +3028,14 @@ export const CHAINS: Chain[] = [
     symbol: "EGLD",
     family: "multiversx",
     explorers: [
-      { name: "MultiversX Explorer", baseUrl: "https://explorer.multiversx.com", addressPath: "/accounts/{query}", txPath: "/transactions/{query}" },
+      {
+        name: "MultiversX Explorer",
+        baseUrl: "https://explorer.multiversx.com",
+        addressPath: "/accounts/{query}",
+        txPath: "/transactions/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.multiversx.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.multiversx.com", provider: "public" }],
   },
   {
     id: "starknet",
@@ -1909,11 +3043,24 @@ export const CHAINS: Chain[] = [
     symbol: "STRK",
     family: "starknet",
     explorers: [
-      { name: "Starkscan", baseUrl: "https://starkscan.co", addressPath: "/contract/{query}", txPath: "/tx/{query}" },
-      { name: "Voyager", baseUrl: "https://voyager.online", addressPath: "/contract/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Starkscan",
+        baseUrl: "https://starkscan.co",
+        addressPath: "/contract/{query}",
+        txPath: "/tx/{query}",
+      },
+      {
+        name: "Voyager",
+        baseUrl: "https://voyager.online",
+        addressPath: "/contract/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://free-rpc.nethermind.io/mainnet-juno/", provider: "public" },
+      {
+        url: "https://free-rpc.nethermind.io/mainnet-juno/",
+        provider: "public",
+      },
     ],
   },
 
@@ -1925,11 +3072,20 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Etherscan Sepolia", baseUrl: "https://sepolia.etherscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Etherscan Sepolia",
+        baseUrl: "https://sepolia.etherscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 11155111,
     rpcUrls: [
-      { url: "https://ethereum-sepolia-rpc.publicnode.com", provider: "public" },
+      {
+        url: "https://ethereum-sepolia-rpc.publicnode.com",
+        provider: "public",
+      },
     ],
   },
   {
@@ -1939,11 +3095,20 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Etherscan Holesky", baseUrl: "https://holesky.etherscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Etherscan Holesky",
+        baseUrl: "https://holesky.etherscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 17000,
     rpcUrls: [
-      { url: "https://ethereum-holesky-rpc.publicnode.com", provider: "public" },
+      {
+        url: "https://ethereum-holesky-rpc.publicnode.com",
+        provider: "public",
+      },
     ],
   },
   {
@@ -1953,7 +3118,13 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Basescan Sepolia", baseUrl: "https://sepolia.basescan.org", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Basescan Sepolia",
+        baseUrl: "https://sepolia.basescan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 84532,
     rpcUrls: [
@@ -1967,11 +3138,20 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Arbiscan Sepolia", baseUrl: "https://sepolia.arbiscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Arbiscan Sepolia",
+        baseUrl: "https://sepolia.arbiscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 421614,
     rpcUrls: [
-      { url: "https://arbitrum-sepolia-rpc.publicnode.com", provider: "public" },
+      {
+        url: "https://arbitrum-sepolia-rpc.publicnode.com",
+        provider: "public",
+      },
     ],
   },
   {
@@ -1981,11 +3161,20 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Etherscan Optimism Sepolia", baseUrl: "https://sepolia-optimism.etherscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Etherscan Optimism Sepolia",
+        baseUrl: "https://sepolia-optimism.etherscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 11155420,
     rpcUrls: [
-      { url: "https://optimism-sepolia-rpc.publicnode.com", provider: "public" },
+      {
+        url: "https://optimism-sepolia-rpc.publicnode.com",
+        provider: "public",
+      },
     ],
   },
   {
@@ -1995,11 +3184,20 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Polygonscan Amoy", baseUrl: "https://amoy.polygonscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Polygonscan Amoy",
+        baseUrl: "https://amoy.polygonscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 80002,
     rpcUrls: [
-      { url: "https://polygon-amoy-bor-rpc.publicnode.com", provider: "public" },
+      {
+        url: "https://polygon-amoy-bor-rpc.publicnode.com",
+        provider: "public",
+      },
     ],
   },
   {
@@ -2009,7 +3207,13 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "BscScan Testnet", baseUrl: "https://testnet.bscscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "BscScan Testnet",
+        baseUrl: "https://testnet.bscscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 97,
     rpcUrls: [
@@ -2023,11 +3227,20 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Snowscan Fuji", baseUrl: "https://testnet.snowscan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Snowscan Fuji",
+        baseUrl: "https://testnet.snowscan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     etherscanChainId: 43113,
     rpcUrls: [
-      { url: "https://avalanche-fuji-c-chain-rpc.publicnode.com", provider: "public" },
+      {
+        url: "https://avalanche-fuji-c-chain-rpc.publicnode.com",
+        provider: "public",
+      },
     ],
   },
   {
@@ -2037,7 +3250,13 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "FtmScan Testnet", baseUrl: "https://testnet.ftmscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "FtmScan Testnet",
+        baseUrl: "https://testnet.ftmscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://rpc.testnet.fantom.network", provider: "public" },
@@ -2050,11 +3269,15 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "zkSync Explorer Sepolia", baseUrl: "https://sepolia.explorer.zksync.io", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "zkSync Explorer Sepolia",
+        baseUrl: "https://sepolia.explorer.zksync.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://sepolia.era.zksync.dev", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://sepolia.era.zksync.dev", provider: "public" }],
   },
   {
     id: "linea-sepolia",
@@ -2063,7 +3286,13 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Lineascan Sepolia", baseUrl: "https://sepolia.lineascan.build", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Lineascan Sepolia",
+        baseUrl: "https://sepolia.lineascan.build",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://linea-sepolia-rpc.publicnode.com", provider: "public" },
@@ -2076,7 +3305,13 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Scrollscan Sepolia", baseUrl: "https://sepolia.scrollscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Scrollscan Sepolia",
+        baseUrl: "https://sepolia.scrollscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://scroll-sepolia-rpc.publicnode.com", provider: "public" },
@@ -2089,11 +3324,15 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Mantlescan Sepolia", baseUrl: "https://sepolia.mantlescan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Mantlescan Sepolia",
+        baseUrl: "https://sepolia.mantlescan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://rpc.sepolia.mantle.xyz", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://rpc.sepolia.mantle.xyz", provider: "public" }],
   },
 
   // --- New EVM Testnets ---
@@ -2104,7 +3343,13 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Berascan Testnet", baseUrl: "https://testnet.berascan.com", addressPath: "/address/{query}", txPath: "/tx/{query}", tokenPath: "/token/{query}" },
+      {
+        name: "Berascan Testnet",
+        baseUrl: "https://testnet.berascan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        tokenPath: "/token/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2115,7 +3360,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Ronin Saigon Explorer", baseUrl: "https://saigon-app.roninchain.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Ronin Saigon Explorer",
+        baseUrl: "https://saigon-app.roninchain.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2126,7 +3376,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Flarescan Coston2", baseUrl: "https://coston2.testnet.flarescan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Flarescan Coston2",
+        baseUrl: "https://coston2.testnet.flarescan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://rpc.ankr.com/flare_coston2", provider: "public" },
@@ -2139,7 +3394,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Oasis Explorer Testnet", baseUrl: "https://explorer.oasis.io/testnet/sapphire", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Oasis Explorer Testnet",
+        baseUrl: "https://explorer.oasis.io/testnet/sapphire",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2150,7 +3410,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Core Scan Testnet", baseUrl: "https://scan.test2.btcs.network", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Core Scan Testnet",
+        baseUrl: "https://scan.test2.btcs.network",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2161,7 +3426,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "MonadScan Testnet", baseUrl: "https://testnet.monadscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "MonadScan Testnet",
+        baseUrl: "https://testnet.monadscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2174,7 +3444,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "BlockExplorer.one", baseUrl: "https://blockexplorer.one/ethereum-classic/mordor", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BlockExplorer.one",
+        baseUrl: "https://blockexplorer.one/ethereum-classic/mordor",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2187,7 +3462,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Hypurrscan Testnet", baseUrl: "https://testnet.hypurrscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Hypurrscan Testnet",
+        baseUrl: "https://testnet.hypurrscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://rpc.hyperliquid-testnet.xyz/evm", provider: "public" },
@@ -2200,7 +3480,12 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Hypurrscan Testnet", baseUrl: "https://testnet.hypurrscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Hypurrscan Testnet",
+        baseUrl: "https://testnet.hypurrscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2213,11 +3498,14 @@ export const CHAINS: Chain[] = [
     family: "bitcoin-testnet",
     isTestnet: true,
     explorers: [
-      { name: "mempool.space Testnet", baseUrl: "https://mempool.space/testnet", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "mempool.space Testnet",
+        baseUrl: "https://mempool.space/testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://mempool.space/testnet/api", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://mempool.space/testnet/api", provider: "public" }],
   },
 
   // --- Solana Testnets ---
@@ -2228,11 +3516,14 @@ export const CHAINS: Chain[] = [
     family: "solana",
     isTestnet: true,
     explorers: [
-      { name: "Solana Explorer Testnet", baseUrl: "https://explorer.solana.com", addressPath: "/address/{query}?cluster=testnet", txPath: "/tx/{query}?cluster=testnet" },
+      {
+        name: "Solana Explorer Testnet",
+        baseUrl: "https://explorer.solana.com",
+        addressPath: "/address/{query}?cluster=testnet",
+        txPath: "/tx/{query}?cluster=testnet",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.testnet.solana.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.testnet.solana.com", provider: "public" }],
   },
   {
     id: "solana-devnet",
@@ -2241,11 +3532,14 @@ export const CHAINS: Chain[] = [
     family: "solana",
     isTestnet: true,
     explorers: [
-      { name: "Solana Explorer Devnet", baseUrl: "https://explorer.solana.com", addressPath: "/address/{query}?cluster=devnet", txPath: "/tx/{query}?cluster=devnet" },
+      {
+        name: "Solana Explorer Devnet",
+        baseUrl: "https://explorer.solana.com",
+        addressPath: "/address/{query}?cluster=devnet",
+        txPath: "/tx/{query}?cluster=devnet",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.devnet.solana.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.devnet.solana.com", provider: "public" }],
   },
 
   // --- Cardano Testnet ---
@@ -2256,11 +3550,14 @@ export const CHAINS: Chain[] = [
     family: "cardano",
     isTestnet: true,
     explorers: [
-      { name: "Cardanoscan Preprod", baseUrl: "https://preprod.cardanoscan.io", addressPath: "/address/{query}", txPath: "/transaction/{query}" },
+      {
+        name: "Cardanoscan Preprod",
+        baseUrl: "https://preprod.cardanoscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/transaction/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://preprod.koios.rest/api/v1", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://preprod.koios.rest/api/v1", provider: "public" }],
   },
 
   // --- Move Testnets ---
@@ -2271,11 +3568,14 @@ export const CHAINS: Chain[] = [
     family: "sui",
     isTestnet: true,
     explorers: [
-      { name: "SuiVision Testnet", baseUrl: "https://testnet.suivision.xyz", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "SuiVision Testnet",
+        baseUrl: "https://testnet.suivision.xyz",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://fullnode.testnet.sui.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://fullnode.testnet.sui.io", provider: "public" }],
   },
   {
     id: "aptos-testnet",
@@ -2284,7 +3584,12 @@ export const CHAINS: Chain[] = [
     family: "aptos",
     isTestnet: true,
     explorers: [
-      { name: "Aptos Explorer Testnet", baseUrl: "https://explorer.aptoslabs.com", addressPath: "/account/{query}?network=testnet", txPath: "/txn/{query}?network=testnet" },
+      {
+        name: "Aptos Explorer Testnet",
+        baseUrl: "https://explorer.aptoslabs.com",
+        addressPath: "/account/{query}?network=testnet",
+        txPath: "/txn/{query}?network=testnet",
+      },
     ],
     rpcUrls: [
       { url: "https://fullnode.testnet.aptoslabs.com/v1", provider: "public" },
@@ -2299,11 +3604,14 @@ export const CHAINS: Chain[] = [
     family: "near",
     isTestnet: true,
     explorers: [
-      { name: "NearBlocks Testnet", baseUrl: "https://testnet.nearblocks.io", addressPath: "/address/{query}", txPath: "/txns/{query}" },
+      {
+        name: "NearBlocks Testnet",
+        baseUrl: "https://testnet.nearblocks.io",
+        addressPath: "/address/{query}",
+        txPath: "/txns/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://rpc.testnet.near.org", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://rpc.testnet.near.org", provider: "public" }],
   },
 
   // --- Tron Testnets ---
@@ -2314,11 +3622,14 @@ export const CHAINS: Chain[] = [
     family: "tron",
     isTestnet: true,
     explorers: [
-      { name: "Tronscan Shasta", baseUrl: "https://shasta.tronscan.org", addressPath: "/#/address/{query}", txPath: "/#/transaction/{query}" },
+      {
+        name: "Tronscan Shasta",
+        baseUrl: "https://shasta.tronscan.org",
+        addressPath: "/#/address/{query}",
+        txPath: "/#/transaction/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://api.shasta.trongrid.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://api.shasta.trongrid.io", provider: "public" }],
   },
   {
     id: "tron-nile",
@@ -2327,11 +3638,14 @@ export const CHAINS: Chain[] = [
     family: "tron",
     isTestnet: true,
     explorers: [
-      { name: "Tronscan Nile", baseUrl: "https://nile.tronscan.org", addressPath: "/#/address/{query}", txPath: "/#/transaction/{query}" },
+      {
+        name: "Tronscan Nile",
+        baseUrl: "https://nile.tronscan.org",
+        addressPath: "/#/address/{query}",
+        txPath: "/#/transaction/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://nile.trongrid.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://nile.trongrid.io", provider: "public" }],
   },
 
   // --- TON Testnet ---
@@ -2342,8 +3656,18 @@ export const CHAINS: Chain[] = [
     family: "ton",
     isTestnet: true,
     explorers: [
-      { name: "TON Viewer Testnet", baseUrl: "https://testnet.tonviewer.com", addressPath: "/{query}", txPath: "/transaction/{query}" },
-      { name: "Tonscan Testnet", baseUrl: "https://testnet.tonscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "TON Viewer Testnet",
+        baseUrl: "https://testnet.tonviewer.com",
+        addressPath: "/{query}",
+        txPath: "/transaction/{query}",
+      },
+      {
+        name: "Tonscan Testnet",
+        baseUrl: "https://testnet.tonscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://testnet.toncenter.com/api/v2", provider: "public" },
@@ -2358,11 +3682,24 @@ export const CHAINS: Chain[] = [
     family: "starknet",
     isTestnet: true,
     explorers: [
-      { name: "Starkscan Sepolia", baseUrl: "https://sepolia.starkscan.co", addressPath: "/contract/{query}", txPath: "/tx/{query}" },
-      { name: "Voyager Sepolia", baseUrl: "https://sepolia.voyager.online", addressPath: "/contract/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Starkscan Sepolia",
+        baseUrl: "https://sepolia.starkscan.co",
+        addressPath: "/contract/{query}",
+        txPath: "/tx/{query}",
+      },
+      {
+        name: "Voyager Sepolia",
+        baseUrl: "https://sepolia.voyager.online",
+        addressPath: "/contract/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://free-rpc.nethermind.io/sepolia-juno/", provider: "public" },
+      {
+        url: "https://free-rpc.nethermind.io/sepolia-juno/",
+        provider: "public",
+      },
     ],
   },
 
@@ -2374,7 +3711,12 @@ export const CHAINS: Chain[] = [
     family: "xrp",
     isTestnet: true,
     explorers: [
-      { name: "XRPScan Testnet", baseUrl: "https://testnet.xrpscan.com", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "XRPScan Testnet",
+        baseUrl: "https://testnet.xrpscan.com",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://s.altnet.rippletest.net:51234/", provider: "public" },
@@ -2389,7 +3731,12 @@ export const CHAINS: Chain[] = [
     family: "stellar",
     isTestnet: true,
     explorers: [
-      { name: "StellarExpert Testnet", baseUrl: "https://stellar.expert/explorer/testnet", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "StellarExpert Testnet",
+        baseUrl: "https://stellar.expert/explorer/testnet",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://horizon-testnet.stellar.org", provider: "public" },
@@ -2404,7 +3751,12 @@ export const CHAINS: Chain[] = [
     family: "hedera",
     isTestnet: true,
     explorers: [
-      { name: "HashScan Testnet", baseUrl: "https://hashscan.io", addressPath: "/testnet/account/{query}", txPath: "/testnet/transaction/{query}" },
+      {
+        name: "HashScan Testnet",
+        baseUrl: "https://hashscan.io",
+        addressPath: "/testnet/account/{query}",
+        txPath: "/testnet/transaction/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://testnet.mirrornode.hedera.com", provider: "public" },
@@ -2419,7 +3771,12 @@ export const CHAINS: Chain[] = [
     family: "algorand",
     isTestnet: true,
     explorers: [
-      { name: "Allo.info Testnet", baseUrl: "https://testnet.allo.info", addressPath: "/account/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Allo.info Testnet",
+        baseUrl: "https://testnet.allo.info",
+        addressPath: "/account/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
       { url: "https://testnet-idx.algonode.cloud", provider: "public" },
@@ -2434,11 +3791,14 @@ export const CHAINS: Chain[] = [
     family: "multiversx",
     isTestnet: true,
     explorers: [
-      { name: "MultiversX Devnet Explorer", baseUrl: "https://devnet-explorer.multiversx.com", addressPath: "/accounts/{query}", txPath: "/transactions/{query}" },
+      {
+        name: "MultiversX Devnet Explorer",
+        baseUrl: "https://devnet-explorer.multiversx.com",
+        addressPath: "/accounts/{query}",
+        txPath: "/transactions/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://devnet-api.multiversx.com", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://devnet-api.multiversx.com", provider: "public" }],
   },
 
   // --- Polkadot Testnet ---
@@ -2449,11 +3809,14 @@ export const CHAINS: Chain[] = [
     family: "polkadot",
     isTestnet: true,
     explorers: [
-      { name: "Subscan Westend", baseUrl: "https://westend.subscan.io", addressPath: "/account/{query}", txPath: "/extrinsic/{query}" },
+      {
+        name: "Subscan Westend",
+        baseUrl: "https://westend.subscan.io",
+        addressPath: "/account/{query}",
+        txPath: "/extrinsic/{query}",
+      },
     ],
-    rpcUrls: [
-      { url: "https://westend-rpc.polkadot.io", provider: "public" },
-    ],
+    rpcUrls: [{ url: "https://westend-rpc.polkadot.io", provider: "public" }],
   },
 
   // --- Filecoin Testnet ---
@@ -2464,10 +3827,18 @@ export const CHAINS: Chain[] = [
     family: "filecoin",
     isTestnet: true,
     explorers: [
-      { name: "Filfox Calibration", baseUrl: "https://calibration.filfox.info", addressPath: "/en/address/{query}", txPath: "/en/message/{query}" },
+      {
+        name: "Filfox Calibration",
+        baseUrl: "https://calibration.filfox.info",
+        addressPath: "/en/address/{query}",
+        txPath: "/en/message/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://api.calibration.node.glif.io/rpc/v1", provider: "public" },
+      {
+        url: "https://api.calibration.node.glif.io/rpc/v1",
+        provider: "public",
+      },
     ],
   },
 
@@ -2479,7 +3850,12 @@ export const CHAINS: Chain[] = [
     family: "litecoin",
     isTestnet: true,
     explorers: [
-      { name: "BlockExplorer.one", baseUrl: "https://blockexplorer.one/litecoin/testnet", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BlockExplorer.one",
+        baseUrl: "https://blockexplorer.one/litecoin/testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2492,7 +3868,12 @@ export const CHAINS: Chain[] = [
     family: "dogecoin",
     isTestnet: true,
     explorers: [
-      { name: "BlockExplorer.one", baseUrl: "https://blockexplorer.one/dogecoin/testnet", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BlockExplorer.one",
+        baseUrl: "https://blockexplorer.one/dogecoin/testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2505,7 +3886,12 @@ export const CHAINS: Chain[] = [
     family: "bitcoincash",
     isTestnet: true,
     explorers: [
-      { name: "BlockExplorer.one", baseUrl: "https://blockexplorer.one/bitcoin-cash/testnet", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BlockExplorer.one",
+        baseUrl: "https://blockexplorer.one/bitcoin-cash/testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2518,7 +3904,12 @@ export const CHAINS: Chain[] = [
     family: "zcash",
     isTestnet: true,
     explorers: [
-      { name: "BlockExplorer.one", baseUrl: "https://blockexplorer.one/zcash/testnet", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BlockExplorer.one",
+        baseUrl: "https://blockexplorer.one/zcash/testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2531,7 +3922,12 @@ export const CHAINS: Chain[] = [
     family: "dash",
     isTestnet: true,
     explorers: [
-      { name: "BlockExplorer.one", baseUrl: "https://blockexplorer.one/dash/testnet", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BlockExplorer.one",
+        baseUrl: "https://blockexplorer.one/dash/testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2544,7 +3940,12 @@ export const CHAINS: Chain[] = [
     family: "lightning",
     isTestnet: true,
     explorers: [
-      { name: "mempool.space Testnet", baseUrl: "https://mempool.space/testnet/lightning", addressPath: "/node/{query}", txPath: "" },
+      {
+        name: "mempool.space Testnet",
+        baseUrl: "https://mempool.space/testnet/lightning",
+        addressPath: "/node/{query}",
+        txPath: "",
+      },
     ],
     rpcUrls: [],
   },
@@ -2557,7 +3958,12 @@ export const CHAINS: Chain[] = [
     family: "kaspa",
     isTestnet: true,
     explorers: [
-      { name: "Kaspa Explorer Testnet", baseUrl: "https://explorer-tn11.kaspa.org", addressPath: "/addresses/{query}", txPath: "/txs/{query}" },
+      {
+        name: "Kaspa Explorer Testnet",
+        baseUrl: "https://explorer-tn11.kaspa.org",
+        addressPath: "/addresses/{query}",
+        txPath: "/txs/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2570,7 +3976,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/osmosis-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/osmosis-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2581,7 +3993,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/celestia-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/celestia-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2592,7 +4010,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/dydx-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/dydx-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2603,7 +4027,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/injective-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/injective-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2614,7 +4044,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/axelar-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/axelar-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2625,7 +4061,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/kava-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/kava-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2636,7 +4078,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/persistence-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/persistence-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2647,7 +4095,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/archway-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/archway-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2658,7 +4112,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/noble-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/noble-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2669,7 +4129,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/neutron-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/neutron-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2680,7 +4146,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/coreum-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/coreum-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2691,7 +4163,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/mantra-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/mantra-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2702,7 +4180,13 @@ export const CHAINS: Chain[] = [
     family: "cosmos",
     isTestnet: true,
     explorers: [
-      { name: "Mintscan", baseUrl: "https://www.mintscan.io/babylon-testnet", addressPath: "/address/{query}", txPath: "/tx/{query}", validatorPath: "/validators/{query}" },
+      {
+        name: "Mintscan",
+        baseUrl: "https://www.mintscan.io/babylon-testnet",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+        validatorPath: "/validators/{query}",
+      },
     ],
     rpcUrls: [],
   },
@@ -2715,10 +4199,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Blockscout Chiado", baseUrl: "https://gnosis-chiado.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Blockscout Chiado",
+        baseUrl: "https://gnosis-chiado.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://gnosis-chiado.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://gnosis-chiado.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2728,10 +4221,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Blastscan Sepolia", baseUrl: "https://sepolia.blastscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Blastscan Sepolia",
+        baseUrl: "https://sepolia.blastscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://blast-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://blast-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2741,10 +4243,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Worldscan Sepolia", baseUrl: "https://sepolia.worldscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Worldscan Sepolia",
+        baseUrl: "https://sepolia.worldscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://worldchain-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://worldchain-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2754,10 +4265,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Zora Sepolia Explorer", baseUrl: "https://sepolia.explorer.zora.energy", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Zora Sepolia Explorer",
+        baseUrl: "https://sepolia.explorer.zora.energy",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://zora-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://zora-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2767,10 +4287,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Uniscan Sepolia", baseUrl: "https://sepolia.uniscan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Uniscan Sepolia",
+        baseUrl: "https://sepolia.uniscan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://unichain-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://unichain-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2780,10 +4309,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Celoscan Sepolia", baseUrl: "https://sepolia.celoscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Celoscan Sepolia",
+        baseUrl: "https://sepolia.celoscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://celo-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://celo-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2793,10 +4331,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Apescan Curtis", baseUrl: "https://curtis.apescan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Apescan Curtis",
+        baseUrl: "https://curtis.apescan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://apechain-curtis.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://apechain-curtis.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2806,10 +4353,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Polygon zkEVM Cardona Scan", baseUrl: "https://cardona-zkevm.polygonscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Polygon zkEVM Cardona Scan",
+        baseUrl: "https://cardona-zkevm.polygonscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://polygonzkevm-cardona.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://polygonzkevm-cardona.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2819,10 +4375,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "opBNBscan Testnet", baseUrl: "https://testnet.opbnbscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "opBNBscan Testnet",
+        baseUrl: "https://testnet.opbnbscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://opbnb-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://opbnb-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2832,10 +4397,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Sonicscan Testnet", baseUrl: "https://testnet.sonicscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Sonicscan Testnet",
+        baseUrl: "https://testnet.sonicscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://sonic-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://sonic-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2845,10 +4419,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Abscan Testnet", baseUrl: "https://testnet.abscan.org", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Abscan Testnet",
+        baseUrl: "https://testnet.abscan.org",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://abstract-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://abstract-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2858,10 +4441,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Soneium Minato Explorer", baseUrl: "https://soneium-minato.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Soneium Minato Explorer",
+        baseUrl: "https://soneium-minato.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://soneium-minato.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://soneium-minato.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2871,10 +4463,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Modescan Sepolia", baseUrl: "https://sepolia.modescan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Modescan Sepolia",
+        baseUrl: "https://sepolia.modescan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://mode-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://mode-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2884,10 +4485,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Bobascan Sepolia", baseUrl: "https://sepolia.bobascan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Bobascan Sepolia",
+        baseUrl: "https://sepolia.bobascan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://boba-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://boba-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2897,10 +4507,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "BOB Sepolia Explorer", baseUrl: "https://testnet-explorer.gobob.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "BOB Sepolia Explorer",
+        baseUrl: "https://testnet-explorer.gobob.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://bob-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://bob-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2910,10 +4529,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "ZetaChain Testnet Explorer", baseUrl: "https://athens.explorer.zetachain.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "ZetaChain Testnet Explorer",
+        baseUrl: "https://athens.explorer.zetachain.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://zetachain-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://zetachain-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2923,10 +4551,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Fraxscan Sepolia", baseUrl: "https://sepolia.fraxscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Fraxscan Sepolia",
+        baseUrl: "https://sepolia.fraxscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://frax-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://frax-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2936,10 +4573,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Rootstock Testnet Explorer", baseUrl: "https://rootstock-testnet.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Rootstock Testnet Explorer",
+        baseUrl: "https://rootstock-testnet.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://rootstock-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://rootstock-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2949,10 +4595,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Flowscan EVM Testnet", baseUrl: "https://evm-testnet.flowscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Flowscan EVM Testnet",
+        baseUrl: "https://evm-testnet.flowscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://flow-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://flow-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2962,10 +4617,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Ink Sepolia Explorer", baseUrl: "https://explorer-sepolia.inkonchain.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Ink Sepolia Explorer",
+        baseUrl: "https://explorer-sepolia.inkonchain.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://ink-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://ink-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2975,10 +4639,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Shapescan Sepolia", baseUrl: "https://sepolia.shapescan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Shapescan Sepolia",
+        baseUrl: "https://sepolia.shapescan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://shape-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://shape-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -2988,10 +4661,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Superseed Sepolia Explorer", baseUrl: "https://sepolia-explorer.superseed.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Superseed Sepolia Explorer",
+        baseUrl: "https://sepolia-explorer.superseed.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://superseed-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://superseed-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3001,10 +4683,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Polynomialscan Sepolia", baseUrl: "https://sepolia.polynomialscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Polynomialscan Sepolia",
+        baseUrl: "https://sepolia.polynomialscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://polynomial-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://polynomial-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3014,10 +4705,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Storyscan Aeneid", baseUrl: "https://aeneid.storyscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Storyscan Aeneid",
+        baseUrl: "https://aeneid.storyscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://story-aeneid.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://story-aeneid.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3027,10 +4727,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Lens Sepolia Explorer", baseUrl: "https://explorer.sepolia.lens.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Lens Sepolia Explorer",
+        baseUrl: "https://explorer.sepolia.lens.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://lens-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://lens-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3040,10 +4749,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Anime Sepolia Explorer", baseUrl: "https://sepolia.explorer.anime.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Anime Sepolia Explorer",
+        baseUrl: "https://sepolia.explorer.anime.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://anime-sepolia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://anime-sepolia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3053,10 +4771,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Citrea Testnet Explorer", baseUrl: "https://explorer.testnet.citrea.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Citrea Testnet Explorer",
+        baseUrl: "https://explorer.testnet.citrea.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://citrea-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://citrea-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3066,10 +4793,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Botanixscan Testnet", baseUrl: "https://testnet.botanixscan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Botanixscan Testnet",
+        baseUrl: "https://testnet.botanixscan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://botanix-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://botanix-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3079,10 +4815,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "XFIscan Testnet", baseUrl: "https://testnet.xfiscan.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "XFIscan Testnet",
+        baseUrl: "https://testnet.xfiscan.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://crossfi-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://crossfi-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3092,10 +4837,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Galactica Testnet Explorer", baseUrl: "https://testnet.explorer.galactica.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Galactica Testnet Explorer",
+        baseUrl: "https://testnet.explorer.galactica.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://galactica-cassiopeia.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://galactica-cassiopeia.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3105,10 +4859,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Humanity Testnet Explorer", baseUrl: "https://humanity-testnet.explorer.alchemy.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Humanity Testnet Explorer",
+        baseUrl: "https://humanity-testnet.explorer.alchemy.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://humanity-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://humanity-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3118,10 +4881,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Stablescan Testnet", baseUrl: "https://testnet.stablescan.xyz", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Stablescan Testnet",
+        baseUrl: "https://testnet.stablescan.xyz",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://stable-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://stable-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3131,10 +4903,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Settlus Testnet Explorer", baseUrl: "https://testnet.settlus.network", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Settlus Testnet Explorer",
+        baseUrl: "https://testnet.settlus.network",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://settlus-septestnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://settlus-septestnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3144,10 +4925,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "Plasma Testnet Scan", baseUrl: "https://testnet.plasmascan.io", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "Plasma Testnet Scan",
+        baseUrl: "https://testnet.plasmascan.io",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://plasma-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://plasma-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3157,10 +4947,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "MegaETH Testnet Explorer", baseUrl: "https://testnet.megaeth.blockscout.com", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "MegaETH Testnet Explorer",
+        baseUrl: "https://testnet.megaeth.blockscout.com",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://megaeth-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://megaeth-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
   {
@@ -3170,10 +4969,19 @@ export const CHAINS: Chain[] = [
     family: "evm",
     isTestnet: true,
     explorers: [
-      { name: "ADI Testnet Explorer", baseUrl: "https://explorer.testnet.adifoundation.ai", addressPath: "/address/{query}", txPath: "/tx/{query}" },
+      {
+        name: "ADI Testnet Explorer",
+        baseUrl: "https://explorer.testnet.adifoundation.ai",
+        addressPath: "/address/{query}",
+        txPath: "/tx/{query}",
+      },
     ],
     rpcUrls: [
-      { url: "https://adi-testnet.g.alchemy.com/v2/{key}", provider: "alchemy", keyEnvVar: "ALCHEMY_API_KEY" },
+      {
+        url: "https://adi-testnet.g.alchemy.com/v2/{key}",
+        provider: "alchemy",
+        keyEnvVar: "ALCHEMY_API_KEY",
+      },
     ],
   },
 ];

--- a/worker/src/detect.test.ts
+++ b/worker/src/detect.test.ts
@@ -12,9 +12,13 @@ function inputTypes(results: DetectionResult[]): string[] {
   return [...new Set(results.map((r) => r.inputType))];
 }
 
-const EVM_CHAINS = CHAINS.filter((c) => c.family === "evm" && !c.isTestnet).map((c) => c.id);
+const EVM_CHAINS = CHAINS.filter((c) => c.family === "evm" && !c.isTestnet).map(
+  (c) => c.id,
+);
 
-const COSMOS_CHAIN_IDS = CHAINS.filter((c) => c.family === "cosmos" && c.bech32Prefix).map((c) => c.id);
+const COSMOS_CHAIN_IDS = CHAINS.filter(
+  (c) => c.family === "cosmos" && c.bech32Prefix,
+).map((c) => c.id);
 
 // --- EVM address (0x + 40 hex) ---
 
@@ -40,15 +44,21 @@ describe("EVM address detection", () => {
   });
 
   it("rejects wrong length (too short)", () => {
-    expect(detect("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604", CHAINS)).toHaveLength(0);
+    expect(
+      detect("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604", CHAINS),
+    ).toHaveLength(0);
   });
 
   it("rejects wrong length (too long)", () => {
-    expect(detect("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA960455", CHAINS)).toHaveLength(0);
+    expect(
+      detect("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA960455", CHAINS),
+    ).toHaveLength(0);
   });
 
   it("rejects invalid hex chars", () => {
-    expect(detect("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604G", CHAINS)).toHaveLength(0);
+    expect(
+      detect("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604G", CHAINS),
+    ).toHaveLength(0);
   });
 });
 
@@ -74,14 +84,20 @@ describe("0x + 64 hex detection", () => {
     const results = detect(hash, CHAINS);
     const sui = results.filter((r) => r.chain.id === "sui");
     expect(sui).toHaveLength(2);
-    expect(sui.map((r) => r.inputType).sort()).toEqual(["address", "transaction"]);
+    expect(sui.map((r) => r.inputType).sort()).toEqual([
+      "address",
+      "transaction",
+    ]);
   });
 
   it("includes Aptos as both address and transaction", () => {
     const results = detect(hash, CHAINS);
     const aptos = results.filter((r) => r.chain.id === "aptos");
     expect(aptos).toHaveLength(2);
-    expect(aptos.map((r) => r.inputType).sort()).toEqual(["address", "transaction"]);
+    expect(aptos.map((r) => r.inputType).sort()).toEqual([
+      "address",
+      "transaction",
+    ]);
   });
 });
 
@@ -107,14 +123,20 @@ describe("IBC denom detection", () => {
 
 describe("factory denom detection", () => {
   it("matches correct cosmos chain by bech32 prefix", () => {
-    const results = detect("factory/osmo1abc123def456ghi789jkl012mno345pqr678stu/utoken", CHAINS);
+    const results = detect(
+      "factory/osmo1abc123def456ghi789jkl012mno345pqr678stu/utoken",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("osmosis");
     expect(results[0].inputType).toBe("denom");
   });
 
   it("rejects unknown prefix", () => {
-    const results = detect("factory/unknown1abc123def456ghi789jkl012mno345pqr678stu/utoken", CHAINS);
+    const results = detect(
+      "factory/unknown1abc123def456ghi789jkl012mno345pqr678stu/utoken",
+      CHAINS,
+    );
     expect(results).toHaveLength(0);
   });
 });
@@ -149,14 +171,20 @@ describe("Cosmos bech32 address detection", () => {
   for (const [prefix, addr] of testCases) {
     it(`detects ${prefix} address`, () => {
       const results = detect(addr, CHAINS);
-      expect(results.length, `No match for ${prefix} address`).toBeGreaterThanOrEqual(1);
+      expect(
+        results.length,
+        `No match for ${prefix} address`,
+      ).toBeGreaterThanOrEqual(1);
       expect(results[0].inputType).toBe("address");
       expect(results[0].chain.bech32Prefix).toBe(prefix);
     });
   }
 
   it("rejects uppercase bech32 address", () => {
-    const results = detect("COSMOS1QYPQXPQ9QCRSSZG2PVXQ6RS0ZQG3YYC5LZV7XU", CHAINS);
+    const results = detect(
+      "COSMOS1QYPQXPQ9QCRSSZG2PVXQ6RS0ZQG3YYC5LZV7XU",
+      CHAINS,
+    );
     expect(results).toHaveLength(0);
   });
 });
@@ -165,34 +193,49 @@ describe("Cosmos bech32 address detection", () => {
 
 describe("Cosmos valoper address detection", () => {
   it("detects cosmosvaloper address", () => {
-    const results = detect("cosmosvaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn", CHAINS);
+    const results = detect(
+      "cosmosvaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("cosmos");
     expect(results[0].inputType).toBe("validator");
   });
 
   it("detects osmovaloper address", () => {
-    const results = detect("osmovaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep88n0y4", CHAINS);
+    const results = detect(
+      "osmovaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep88n0y4",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("osmosis");
     expect(results[0].inputType).toBe("validator");
   });
 
   it("generates Mintscan validator URL", () => {
-    const results = detect("osmovaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep88n0y4", CHAINS);
+    const results = detect(
+      "osmovaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4ep88n0y4",
+      CHAINS,
+    );
     expect(results[0].explorerUrls.length).toBeGreaterThan(0);
     expect(results[0].explorerUrls[0].url).toContain("/validators/");
   });
 
   it("detects celestiavaloper address", () => {
-    const results = detect("celestiavaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4eptv8mxz", CHAINS);
+    const results = detect(
+      "celestiavaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4eptv8mxz",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("celestia");
     expect(results[0].inputType).toBe("validator");
   });
 
   it("does not match regular address as validator", () => {
-    const results = detect("osmo1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc50eacts", CHAINS);
+    const results = detect(
+      "osmo1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc50eacts",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].inputType).toBe("address");
   });
@@ -215,13 +258,19 @@ describe("Bitcoin address detection", () => {
   });
 
   it("detects bech32 address starting with bc1", () => {
-    const results = detect("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", CHAINS);
+    const results = detect(
+      "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("bitcoin");
   });
 
   it("detects taproot address starting with bc1p", () => {
-    const results = detect("bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9", CHAINS);
+    const results = detect(
+      "bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("bitcoin");
   });
@@ -267,7 +316,10 @@ describe("Litecoin address detection", () => {
   });
 
   it("detects ltc1 bech32 address", () => {
-    const results = detect("ltc1qar0srrr7xfkvy5l643lydnw9re59gtzzwfhmdq", CHAINS);
+    const results = detect(
+      "ltc1qar0srrr7xfkvy5l643lydnw9re59gtzzwfhmdq",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("litecoin");
   });
@@ -468,13 +520,19 @@ describe("Filecoin detection", () => {
   });
 
   it("detects f3 address (BLS)", () => {
-    const results = detect("f3vfs6f7tagrcpnwv65wq3leznbajqyg77bmijrpvoyjv3zjyi3urq25vigfbs3ob6ug5xdihajumtgsxnz2pa", CHAINS);
+    const results = detect(
+      "f3vfs6f7tagrcpnwv65wq3leznbajqyg77bmijrpvoyjv3zjyi3urq25vigfbs3ob6ug5xdihajumtgsxnz2pa",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("filecoin");
   });
 
   it("detects bafy CID as transaction", () => {
-    const results = detect("bafy2bzacedfto5wl5xbafi3yiop6xfbji4wnr2qhp64zra73wku7qdmcuwsta", CHAINS);
+    const results = detect(
+      "bafy2bzacedfto5wl5xbafi3yiop6xfbji4wnr2qhp64zra73wku7qdmcuwsta",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("filecoin");
     expect(results[0].inputType).toBe("transaction");
@@ -500,7 +558,9 @@ describe("Hedera detection", () => {
   it("generates explorer URLs", () => {
     const results = detect("0.0.1234567", CHAINS);
     expect(results[0].explorerUrls[0].name).toBe("HashScan");
-    expect(results[0].explorerUrls[0].url).toContain("/mainnet/account/0.0.1234567");
+    expect(results[0].explorerUrls[0].url).toContain(
+      "/mainnet/account/0.0.1234567",
+    );
   });
 });
 
@@ -508,7 +568,10 @@ describe("Hedera detection", () => {
 
 describe("Kaspa detection", () => {
   it("detects kaspa: prefixed address", () => {
-    const results = detect("kaspa:qr6m0t8gkfhsn0l5ynfadtvuetg3fle940dalpsqqaqeqqq4lujwsg3wrr50", CHAINS);
+    const results = detect(
+      "kaspa:qr6m0t8gkfhsn0l5ynfadtvuetg3fle940dalpsqqaqeqqq4lujwsg3wrr50",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("kaspa");
     expect(results[0].inputType).toBe("address");
@@ -585,13 +648,18 @@ describe("Starknet detection", () => {
     const results = detect(hash, CHAINS);
     const starknet = results.filter((r) => r.chain.id === "starknet");
     expect(starknet).toHaveLength(2);
-    expect(starknet.map((r) => r.inputType).sort()).toEqual(["address", "transaction"]);
+    expect(starknet.map((r) => r.inputType).sort()).toEqual([
+      "address",
+      "transaction",
+    ]);
   });
 
   it("generates explorer URLs", () => {
     const hash = "0x" + "a".repeat(64);
     const results = detect(hash, CHAINS);
-    const starknetAddr = results.find((r) => r.chain.id === "starknet" && r.inputType === "address")!;
+    const starknetAddr = results.find(
+      (r) => r.chain.id === "starknet" && r.inputType === "address",
+    )!;
     expect(starknetAddr.explorerUrls.length).toBe(2);
     expect(starknetAddr.explorerUrls[0].name).toBe("Starkscan");
     expect(starknetAddr.explorerUrls[0].url).toContain("/contract/");
@@ -614,14 +682,20 @@ describe("Tron address detection", () => {
 
 describe("TON address detection", () => {
   it("detects EQ + 46 chars with hyphens/underscores", () => {
-    const results = detect("EQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG", CHAINS);
+    const results = detect(
+      "EQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("ton");
     expect(results[0].inputType).toBe("address");
   });
 
   it("detects UQ prefix", () => {
-    const results = detect("UQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG", CHAINS);
+    const results = detect(
+      "UQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("ton");
   });
@@ -710,7 +784,9 @@ describe("bare 64 hex detection", () => {
   it("includes Bitcoin tx", () => {
     const results = detect(hex64, CHAINS);
     expect(chainIds(results)).toContain("bitcoin");
-    expect(results.find((r) => r.chain.id === "bitcoin")!.inputType).toBe("transaction");
+    expect(results.find((r) => r.chain.id === "bitcoin")!.inputType).toBe(
+      "transaction",
+    );
   });
 
   it("includes all Cosmos chains as tx", () => {
@@ -722,36 +798,64 @@ describe("bare 64 hex detection", () => {
 
   it("includes UTXO chains as tx", () => {
     const results = detect(hex64, CHAINS);
-    expect(results.find((r) => r.chain.id === "dogecoin")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "litecoin")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "bitcoin-cash")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "zcash")!.inputType).toBe("transaction");
+    expect(results.find((r) => r.chain.id === "dogecoin")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "litecoin")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "bitcoin-cash")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "zcash")!.inputType).toBe(
+      "transaction",
+    );
   });
 
   it("includes Tron tx, TON tx, Polkadot tx", () => {
     const results = detect(hex64, CHAINS);
-    expect(results.find((r) => r.chain.id === "tron")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "ton")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "polkadot")!.inputType).toBe("transaction");
+    expect(results.find((r) => r.chain.id === "tron")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "ton")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "polkadot")!.inputType).toBe(
+      "transaction",
+    );
   });
 
   it("includes NEAR as address (implicit account)", () => {
     const results = detect(hex64, CHAINS);
-    expect(results.find((r) => r.chain.id === "near")!.inputType).toBe("address");
+    expect(results.find((r) => r.chain.id === "near")!.inputType).toBe(
+      "address",
+    );
   });
 
   it("includes Monero, XRP, Stellar, Cardano as tx", () => {
     const results = detect(hex64, CHAINS);
-    expect(results.find((r) => r.chain.id === "monero")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "xrp")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "stellar")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "cardano")!.inputType).toBe("transaction");
+    expect(results.find((r) => r.chain.id === "monero")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "xrp")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "stellar")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "cardano")!.inputType).toBe(
+      "transaction",
+    );
   });
 
   it("includes MultiversX and Kaspa as tx", () => {
     const results = detect(hex64, CHAINS);
-    expect(results.find((r) => r.chain.id === "multiversx")!.inputType).toBe("transaction");
-    expect(results.find((r) => r.chain.id === "kaspa")!.inputType).toBe("transaction");
+    expect(results.find((r) => r.chain.id === "multiversx")!.inputType).toBe(
+      "transaction",
+    );
+    expect(results.find((r) => r.chain.id === "kaspa")!.inputType).toBe(
+      "transaction",
+    );
   });
 });
 
@@ -842,7 +946,9 @@ describe("edge cases", () => {
 
   it("rejects non-base58 in Bitcoin addresses (0, O, I, l)", () => {
     // 'O' is not in base58
-    expect(detect("1O1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", CHAINS)).toHaveLength(0);
+    expect(detect("1O1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", CHAINS)).toHaveLength(
+      0,
+    );
   });
 
   it("rejects random text", () => {
@@ -854,7 +960,10 @@ describe("edge cases", () => {
 
 describe("Litecoin testnet detection", () => {
   it("detects tltc1 bech32 address", () => {
-    const results = detect("tltc1qar0srrr7xfkvy5l643lydnw9re59gtzzwfhmdq", CHAINS);
+    const results = detect(
+      "tltc1qar0srrr7xfkvy5l643lydnw9re59gtzzwfhmdq",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("litecoin-testnet");
     expect(results[0].inputType).toBe("address");
@@ -886,7 +995,10 @@ describe("Filecoin Calibration testnet detection", () => {
 
 describe("Kaspa testnet detection", () => {
   it("detects kaspatest: prefixed address", () => {
-    const results = detect("kaspatest:qr6m0t8gkfhsn0l5ynfadtvuetg3fle940dalpsqqaqeqqq4lujwsg3wrr50", CHAINS);
+    const results = detect(
+      "kaspatest:qr6m0t8gkfhsn0l5ynfadtvuetg3fle940dalpsqqaqeqqq4lujwsg3wrr50",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("kaspa-testnet");
     expect(results[0].inputType).toBe("address");
@@ -895,7 +1007,10 @@ describe("Kaspa testnet detection", () => {
 
 describe("Bitcoin testnet detection", () => {
   it("detects tb1 bech32 address", () => {
-    const results = detect("tb1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq", CHAINS);
+    const results = detect(
+      "tb1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("bitcoin-testnet");
     expect(results[0].inputType).toBe("address");
@@ -939,7 +1054,10 @@ describe("Bitcoin Cash testnet detection", () => {
 
 describe("THORChain address detection", () => {
   it("detects thor bech32 address", () => {
-    const results = detect("thor13r58hsww07rassmm98kual9x4k4gp53fxzcus5", CHAINS);
+    const results = detect(
+      "thor13r58hsww07rassmm98kual9x4k4gp53fxzcus5",
+      CHAINS,
+    );
     expect(results).toHaveLength(1);
     expect(results[0].chain.id).toBe("thorchain");
     expect(results[0].inputType).toBe("address");
@@ -1179,16 +1297,23 @@ describe("Nockchain detection", () => {
     expect(results).toHaveLength(2);
     const nock = results.filter((r) => r.chain.id === "nockchain");
     expect(nock).toHaveLength(2);
-    expect(nock.map((r) => r.inputType).sort()).toEqual(["address", "transaction"]);
+    expect(nock.map((r) => r.inputType).sort()).toEqual([
+      "address",
+      "transaction",
+    ]);
   });
 
   it("generates NockBlocks explorer URLs", () => {
     const addr = "51qFuv98Rg3Jg4Ka92KGdXEh16ocuzTmDZFH9wyCTeVHwaBwGSNHjWW";
     const results = detect(addr, CHAINS);
-    const nockAddr = results.find((r) => r.chain.id === "nockchain" && r.inputType === "address")!;
+    const nockAddr = results.find(
+      (r) => r.chain.id === "nockchain" && r.inputType === "address",
+    )!;
     expect(nockAddr.explorerUrls[0].name).toBe("NockBlocks");
     expect(nockAddr.explorerUrls[0].url).toContain("/address/");
-    const nockTx = results.find((r) => r.chain.id === "nockchain" && r.inputType === "transaction")!;
+    const nockTx = results.find(
+      (r) => r.chain.id === "nockchain" && r.inputType === "transaction",
+    )!;
     expect(nockTx.explorerUrls[0].url).toContain("/tx/");
   });
 

--- a/worker/src/detect.ts
+++ b/worker/src/detect.ts
@@ -5,31 +5,53 @@ interface Match {
   inputType: InputType;
 }
 
-const BASE58_CHAR = "[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]";
+const BASE58_CHAR =
+  "[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]";
 
 // Urbit phoneme tables (256 suffixes, 256 prefixes)
-const URBIT_SUFFIXES = new Set("zod nec bud wes sev per sut let ful pen syt dur wep ser wyl sun ryp syx dyr nup heb peg lup dep dys put lug hec ryt tyv syd nex lun mep lut sep pes del sul ped tem led tul met wen byn hex feb pyl dul het mev rut tyl wyd tep bes dex sef wyc bur der nep pur rys reb den nut sub pet rul syn reg tyd sup sem wyn rec meg net sec mul nym tev web sum mut nyx rex teb fus hep ben mus wyx sym sel ruc dec wex syr wet dyl myn mes det bet bel tux tug myr pel syp ter meb set dut deg tex sur fel tud nux rux ren wyt nub med lyt dus neb rum tyn seg lyx pun res red fun rev ref mec ted rus bex leb dux ryn num pyx ryg ryx fep tyr tus tyc leg nem fer mer ten lus nus syl tec mex pub rym tuc fyl lep deb ber mug hut tun byl sud pem dev lur def bus bep run mel pex dyt byt typ lev myl wed duc fur fex nul luc len ner lex rup ned lec ryd lyd fen wel nyd hus rel rud nes hes fet des ret dun ler nyr seb hul ryl lud rem lys fyn wer ryc sug nys nyl lyn dyn dem lux fed sed bec mun lyr tes mud nyt byr sen weg fyr mur tel rep teg pec nel nev fes".split(" "));
-const URBIT_PREFIXES = new Set("doz mar bin wan sam lit sig hid fid lis sog dir wac sab wis sib rig sol dop mod fog lid hop dar dor lor hod fol rin tog sil mir hol pas lac rov liv dal sat lib tab han tic pid tor bol fos dot los dil for pil ram tir win tad bic dif roc wid bis das mid lop ril nar dap mol san loc nov sit nid tip sic rop wit nat pan min rit pod mot tam tol sav pos nap nop som fin fon ban mor wor sip ron nor bot wic soc wat dol mag pic dav bid bal tim tas mal lig siv tag pad sal div dac tan sid fab tar mon ran nis wol mis pal las dis map rab tob rol lat lon nod nav fig nom nib pag sop ral bil had doc rid moc pac rav rip fal tod til tin hap mic fan pat tac lab mog sim son pin lom ric tap fir has bos bat poc hac tid hav sap lin dib hos dab bit bar rac par lod dos bor toc hil mac tom dig fil fas mit hob har mig hin rad mas hal rag lag fad top mop hab nil nos mil fop fam dat nol din hat nac ris fot rib hoc nim lar fit wal rap sar nal mos lan don dan lad dov riv bac pol lap tal pit nam bon ros ton fod pon sov noc sor lav mat mip fip".split(" "));
+const URBIT_SUFFIXES = new Set(
+  "zod nec bud wes sev per sut let ful pen syt dur wep ser wyl sun ryp syx dyr nup heb peg lup dep dys put lug hec ryt tyv syd nex lun mep lut sep pes del sul ped tem led tul met wen byn hex feb pyl dul het mev rut tyl wyd tep bes dex sef wyc bur der nep pur rys reb den nut sub pet rul syn reg tyd sup sem wyn rec meg net sec mul nym tev web sum mut nyx rex teb fus hep ben mus wyx sym sel ruc dec wex syr wet dyl myn mes det bet bel tux tug myr pel syp ter meb set dut deg tex sur fel tud nux rux ren wyt nub med lyt dus neb rum tyn seg lyx pun res red fun rev ref mec ted rus bex leb dux ryn num pyx ryg ryx fep tyr tus tyc leg nem fer mer ten lus nus syl tec mex pub rym tuc fyl lep deb ber mug hut tun byl sud pem dev lur def bus bep run mel pex dyt byt typ lev myl wed duc fur fex nul luc len ner lex rup ned lec ryd lyd fen wel nyd hus rel rud nes hes fet des ret dun ler nyr seb hul ryl lud rem lys fyn wer ryc sug nys nyl lyn dyn dem lux fed sed bec mun lyr tes mud nyt byr sen weg fyr mur tel rep teg pec nel nev fes".split(
+    " ",
+  ),
+);
+const URBIT_PREFIXES = new Set(
+  "doz mar bin wan sam lit sig hid fid lis sog dir wac sab wis sib rig sol dop mod fog lid hop dar dor lor hod fol rin tog sil mir hol pas lac rov liv dal sat lib tab han tic pid tor bol fos dot los dil for pil ram tir win tad bic dif roc wid bis das mid lop ril nar dap mol san loc nov sit nid tip sic rop wit nat pan min rit pod mot tam tol sav pos nap nop som fin fon ban mor wor sip ron nor bot wic soc wat dol mag pic dav bid bal tim tas mal lig siv tag pad sal div dac tan sid fab tar mon ran nis wol mis pal las dis map rab tob rol lat lon nod nav fig nom nib pag sop ral bil had doc rid moc pac rav rip fal tod til tin hap mic fan pat tac lab mog sim son pin lom ric tap fir has bos bat poc hac tid hav sap lin dib hos dab bit bar rac par lod dos bor toc hil mac tom dig fil fas mit hob har mig hin rad mas hal rag lag fad top mop hab nil nos mil fop fam dat nol din hat nac ris fot rib hoc nim lar fit wal rap sar nal mos lan don dan lad dov riv bac pol lap tal pit nam bon ros ton fod pon sov noc sor lav mat mip fip".split(
+    " ",
+  ),
+);
 
 function isValidUrbitName(name: string): boolean {
   // Galaxy: single suffix (3 chars)
   if (name.length === 3) return URBIT_SUFFIXES.has(name);
   // Star: prefix + suffix (6 chars)
-  if (name.length === 6) return URBIT_PREFIXES.has(name.slice(0, 3)) && URBIT_SUFFIXES.has(name.slice(3));
+  if (name.length === 6)
+    return (
+      URBIT_PREFIXES.has(name.slice(0, 3)) && URBIT_SUFFIXES.has(name.slice(3))
+    );
   // Planet: prefix+suffix-prefix+suffix (13 chars with hyphen)
   if (name.length === 13 && name[6] === "-") {
-    return URBIT_PREFIXES.has(name.slice(0, 3)) && URBIT_SUFFIXES.has(name.slice(3, 6))
-      && URBIT_PREFIXES.has(name.slice(7, 10)) && URBIT_SUFFIXES.has(name.slice(10, 13));
+    return (
+      URBIT_PREFIXES.has(name.slice(0, 3)) &&
+      URBIT_SUFFIXES.has(name.slice(3, 6)) &&
+      URBIT_PREFIXES.has(name.slice(7, 10)) &&
+      URBIT_SUFFIXES.has(name.slice(10, 13))
+    );
   }
   return false;
 }
 
 // Build EVM chain ID list from CHAINS data
-const EVM_CHAIN_IDS = CHAINS.filter((c) => c.family === "evm" && !c.isTestnet).map((c) => c.id);
+const EVM_CHAIN_IDS = CHAINS.filter(
+  (c) => c.family === "evm" && !c.isTestnet,
+).map((c) => c.id);
 
 // Build Cosmos lookup tables from CHAINS data
-const COSMOS_CHAINS_LIST = CHAINS.filter((c) => c.family === "cosmos" && c.bech32Prefix);
-const BECH32_PREFIX_TO_CHAIN = new Map(COSMOS_CHAINS_LIST.map((c) => [c.bech32Prefix!, c.id]));
+const COSMOS_CHAINS_LIST = CHAINS.filter(
+  (c) => c.family === "cosmos" && c.bech32Prefix,
+);
+const BECH32_PREFIX_TO_CHAIN = new Map(
+  COSMOS_CHAINS_LIST.map((c) => [c.bech32Prefix!, c.id]),
+);
 const COSMOS_CHAIN_IDS = COSMOS_CHAINS_LIST.map((c) => c.id);
 
 function getMatches(input: string): Match[] {
@@ -53,17 +75,32 @@ function getMatches(input: string): Match[] {
       matches.push({ chainId: id, inputType: "transaction" });
     }
     // Sui address or transaction (both are 0x + 64 hex)
-    matches.push({ chainId: "sui", inputType: "address" }, { chainId: "sui", inputType: "transaction" });
+    matches.push(
+      { chainId: "sui", inputType: "address" },
+      { chainId: "sui", inputType: "transaction" },
+    );
     // Aptos address or transaction
-    matches.push({ chainId: "aptos", inputType: "address" }, { chainId: "aptos", inputType: "transaction" });
+    matches.push(
+      { chainId: "aptos", inputType: "address" },
+      { chainId: "aptos", inputType: "transaction" },
+    );
     // Movement address or transaction (Move-based, same format as Aptos)
-    matches.push({ chainId: "movement", inputType: "address" }, { chainId: "movement", inputType: "transaction" });
+    matches.push(
+      { chainId: "movement", inputType: "address" },
+      { chainId: "movement", inputType: "transaction" },
+    );
     // IOTA address or transaction (post-rebasing, same 0x+64hex format)
-    matches.push({ chainId: "iota", inputType: "address" }, { chainId: "iota", inputType: "transaction" });
+    matches.push(
+      { chainId: "iota", inputType: "address" },
+      { chainId: "iota", inputType: "transaction" },
+    );
     // Bittensor extrinsic hash
     matches.push({ chainId: "bittensor", inputType: "transaction" });
     // Starknet address or transaction
-    matches.push({ chainId: "starknet", inputType: "address" }, { chainId: "starknet", inputType: "transaction" });
+    matches.push(
+      { chainId: "starknet", inputType: "address" },
+      { chainId: "starknet", inputType: "transaction" },
+    );
     // Stacks transaction
     matches.push({ chainId: "stacks", inputType: "transaction" });
     return matches;
@@ -440,7 +477,11 @@ export interface DetectionResult {
   explorerUrls: ExplorerUrl[];
 }
 
-function buildExplorerUrls(chain: Chain, inputType: InputType, query: string): ExplorerUrl[] {
+function buildExplorerUrls(
+  chain: Chain,
+  inputType: InputType,
+  query: string,
+): ExplorerUrl[] {
   return chain.explorers
     .map((explorer) => {
       let pathTemplate: string;
@@ -451,7 +492,8 @@ function buildExplorerUrls(chain: Chain, inputType: InputType, query: string): E
         if (!explorer.validatorPath) return null;
         pathTemplate = explorer.validatorPath;
       } else {
-        pathTemplate = inputType === "address" ? explorer.addressPath : explorer.txPath;
+        pathTemplate =
+          inputType === "address" ? explorer.addressPath : explorer.txPath;
       }
       const path = pathTemplate.replace("{query}", encodeURIComponent(query));
       return { name: explorer.name, url: `${explorer.baseUrl}${path}` };

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2,7 +2,12 @@ import { CHAINS, Env } from "./chains";
 import { detect } from "./detect";
 import { resolveNameService } from "./resolve";
 import { checkExistingSuggestion, createSuggestion } from "./suggest";
-import { VerifiedResult, detectTokens, getCoinGeckoUrl, verifyResults } from "./verify";
+import {
+  VerifiedResult,
+  detectTokens,
+  getCoinGeckoUrl,
+  verifyResults,
+} from "./verify";
 
 function corsHeaders(): HeadersInit {
   return {
@@ -46,12 +51,19 @@ export default {
     // POST /api/suggest/create — create a new suggestion or upvote existing
     if (url.pathname === "/api/suggest/create" && request.method === "POST") {
       try {
-        const body = (await request.json()) as { networkName?: string; description?: string };
+        const body = (await request.json()) as {
+          networkName?: string;
+          description?: string;
+        };
         const networkName = (body.networkName ?? "").trim();
         if (!networkName) {
           return jsonResponse({ error: "Missing networkName" }, 400);
         }
-        const result = await createSuggestion(networkName, body.description, env);
+        const result = await createSuggestion(
+          networkName,
+          body.description,
+          env,
+        );
         return jsonResponse(result);
       } catch {
         return jsonResponse({ error: "Failed to create suggestion" }, 500);
@@ -66,7 +78,10 @@ export default {
     let input: string;
     let verify = true;
     try {
-      const body = (await request.json()) as { input?: string; verify?: boolean };
+      const body = (await request.json()) as {
+        input?: string;
+        verify?: boolean;
+      };
       input = (body.input ?? "").trim();
       if (body.verify === false) verify = false;
     } catch {
@@ -103,31 +118,42 @@ export default {
         status: "unverified" as const,
         ...(d.chain.isTestnet && { isTestnet: true }),
       }));
-      return jsonResponse({ results, ...resolution && { resolvedName: resolution.resolvedName, resolvedAddress: resolution.resolvedAddress } });
+      return jsonResponse({
+        results,
+        ...(resolution && {
+          resolvedName: resolution.resolvedName,
+          resolvedAddress: resolution.resolvedAddress,
+        }),
+      });
     }
 
     // Single match: skip verification but still detect tokens + CoinGecko URL
     // Multiple matches: verify + detect tokens + CoinGecko URL all in parallel
-    const [verified, tokenChainIds, coinGeckoUrl] = detections.length === 1
-      ? await Promise.all([
-          Promise.resolve(detections.map((d): VerifiedResult => ({
-            chainId: d.chain.id,
-            chainName: d.chain.name,
-            symbol: d.chain.symbol,
-            family: d.chain.family,
-            inputType: d.inputType,
-            explorerUrls: d.explorerUrls,
-            status: "unverified" as const,
-            ...(d.chain.isTestnet && { isTestnet: true }),
-          }))),
-          detectTokens(lookupInput, detections, env),
-          getCoinGeckoUrl(lookupInput, detections),
-        ])
-      : await Promise.all([
-          verifyResults(lookupInput, detections, env),
-          detectTokens(lookupInput, detections, env),
-          getCoinGeckoUrl(lookupInput, detections),
-        ]);
+    const [verified, tokenChainIds, coinGeckoUrl] =
+      detections.length === 1
+        ? await Promise.all([
+            Promise.resolve(
+              detections.map(
+                (d): VerifiedResult => ({
+                  chainId: d.chain.id,
+                  chainName: d.chain.name,
+                  symbol: d.chain.symbol,
+                  family: d.chain.family,
+                  inputType: d.inputType,
+                  explorerUrls: d.explorerUrls,
+                  status: "unverified" as const,
+                  ...(d.chain.isTestnet && { isTestnet: true }),
+                }),
+              ),
+            ),
+            detectTokens(lookupInput, detections, env),
+            getCoinGeckoUrl(lookupInput, detections),
+          ])
+        : await Promise.all([
+            verifyResults(lookupInput, detections, env),
+            detectTokens(lookupInput, detections, env),
+            getCoinGeckoUrl(lookupInput, detections),
+          ]);
 
     // Filter results
     const inputType = detections[0].inputType;
@@ -147,7 +173,10 @@ export default {
         results = verified.filter((r) => r.status !== "not_found");
       } else {
         // No activity anywhere — return all as unverified fallback
-        results = verified.map((r) => ({ ...r, status: "unverified" as const }));
+        results = verified.map((r) => ({
+          ...r,
+          status: "unverified" as const,
+        }));
       }
     } else {
       results = verified;
@@ -165,14 +194,18 @@ export default {
           isToken: true,
           explorerUrls: chain.explorers.map((explorer) => {
             const path = explorer.tokenPath ?? explorer.addressPath;
-            return { name: explorer.name, url: `${explorer.baseUrl}${path.replace("{query}", lookupInput)}` };
+            return {
+              name: explorer.name,
+              url: `${explorer.baseUrl}${path.replace("{query}", lookupInput)}`,
+            };
           }),
         };
       });
     }
 
     // Denom results are always tokens — set isToken and rewrite explorer URLs to denomPath
-    const isDenom = detections.length > 0 && detections[0].inputType === "denom";
+    const isDenom =
+      detections.length > 0 && detections[0].inputType === "denom";
     if (isDenom) {
       const chainMap = new Map(CHAINS.map((c) => [c.id, c]));
       results = results.map((r) => {
@@ -194,8 +227,11 @@ export default {
 
     return jsonResponse({
       results,
-      ...resolution && { resolvedName: resolution.resolvedName, resolvedAddress: resolution.resolvedAddress },
-      ...coinGeckoUrl && { coinGeckoUrl },
+      ...(resolution && {
+        resolvedName: resolution.resolvedName,
+        resolvedAddress: resolution.resolvedAddress,
+      }),
+      ...(coinGeckoUrl && { coinGeckoUrl }),
     });
   },
 };

--- a/worker/src/resolve.test.ts
+++ b/worker/src/resolve.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { detectNameService, resolveNameService, type NameDetection } from "./resolve";
+import {
+  detectNameService,
+  resolveNameService,
+  type NameDetection,
+} from "./resolve";
 import { CHAINS } from "./chains";
 import type { Env } from "./chains";
 
@@ -18,32 +22,56 @@ describe("detectNameService", () => {
 
   it(".bnb → spaceid", () => {
     const result = detectNameService("test.bnb");
-    expect(result).toEqual({ service: "spaceid", name: "test.bnb", tld: "bnb" });
+    expect(result).toEqual({
+      service: "spaceid",
+      name: "test.bnb",
+      tld: "bnb",
+    });
   });
 
   it(".osmo → icns", () => {
     const result = detectNameService("alice.osmo");
-    expect(result).toEqual({ service: "icns", name: "alice.osmo", tld: "osmo" });
+    expect(result).toEqual({
+      service: "icns",
+      name: "alice.osmo",
+      tld: "osmo",
+    });
   });
 
   it(".cosmos → icns", () => {
     const result = detectNameService("bob.cosmos");
-    expect(result).toEqual({ service: "icns", name: "bob.cosmos", tld: "cosmos" });
+    expect(result).toEqual({
+      service: "icns",
+      name: "bob.cosmos",
+      tld: "cosmos",
+    });
   });
 
   it(".ton → tondns", () => {
     const result = detectNameService("wallet.ton");
-    expect(result).toEqual({ service: "tondns", name: "wallet.ton", tld: "ton" });
+    expect(result).toEqual({
+      service: "tondns",
+      name: "wallet.ton",
+      tld: "ton",
+    });
   });
 
   it(".sui → suins", () => {
     const result = detectNameService("myname.sui");
-    expect(result).toEqual({ service: "suins", name: "myname.sui", tld: "sui" });
+    expect(result).toEqual({
+      service: "suins",
+      name: "myname.sui",
+      tld: "sui",
+    });
   });
 
   it(".apt → aptosnames", () => {
     const result = detectNameService("alice.apt");
-    expect(result).toEqual({ service: "aptosnames", name: "alice.apt", tld: "apt" });
+    expect(result).toEqual({
+      service: "aptosnames",
+      name: "alice.apt",
+      tld: "apt",
+    });
   });
 
   it("rejects .com", () => {
@@ -102,26 +130,30 @@ describe("ENS resolution", () => {
     const resolvedAddr = "d8da6bf26964af9d7eed9e03e53415d37aa96045";
     // First call: registry resolver lookup
     // Second call: resolver addr lookup
-    mockFetch.mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const body = typeof init?.body === "string" ? init.body : "";
-      if (body.includes("0x0178b8bf")) {
-        // resolver() call - return a resolver address
-        return jsonResponse({
-          jsonrpc: "2.0",
-          id: 1,
-          result: "0x000000000000000000000000" + "4976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41",
-        });
-      }
-      if (body.includes("0x3b3b57de")) {
-        // addr() call - return the resolved address
-        return jsonResponse({
-          jsonrpc: "2.0",
-          id: 1,
-          result: "0x000000000000000000000000" + resolvedAddr,
-        });
-      }
-      return new Response("", { status: 500 });
-    });
+    mockFetch.mockImplementation(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = typeof init?.body === "string" ? init.body : "";
+        if (body.includes("0x0178b8bf")) {
+          // resolver() call - return a resolver address
+          return jsonResponse({
+            jsonrpc: "2.0",
+            id: 1,
+            result:
+              "0x000000000000000000000000" +
+              "4976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41",
+          });
+        }
+        if (body.includes("0x3b3b57de")) {
+          // addr() call - return the resolved address
+          return jsonResponse({
+            jsonrpc: "2.0",
+            id: 1,
+            result: "0x000000000000000000000000" + resolvedAddr,
+          });
+        }
+        return new Response("", { status: 500 });
+      },
+    );
 
     const result = await resolveNameService("vitalik.eth", env, CHAINS);
     expect(result).not.toBeNull();
@@ -154,7 +186,9 @@ describe("SNS resolution", () => {
     const result = await resolveNameService("bonfida.sol", env, CHAINS);
     expect(result).not.toBeNull();
     expect(result!.resolvedName).toBe("bonfida.sol");
-    expect(result!.resolvedAddress).toBe("7kEBnUfCrjQqDt6we3dEFagxAqKbwnDSgE6X4H3a3Bri");
+    expect(result!.resolvedAddress).toBe(
+      "7kEBnUfCrjQqDt6we3dEFagxAqKbwnDSgE6X4H3a3Bri",
+    );
   });
 
   it("returns null when API returns not ok", async () => {
@@ -170,9 +204,7 @@ describe("SpaceID resolution", () => {
 
   it("resolves .bnb name", async () => {
     const addr = "0x1234567890abcdef1234567890abcdef12345678";
-    mockFetch.mockResolvedValue(
-      jsonResponse({ code: 0, address: addr }),
-    );
+    mockFetch.mockResolvedValue(jsonResponse({ code: 0, address: addr }));
 
     const result = await resolveNameService("test.bnb", env, CHAINS);
     expect(result).not.toBeNull();
@@ -205,9 +237,7 @@ describe("ICNS resolution", () => {
   });
 
   it("returns null when address is empty", async () => {
-    mockFetch.mockResolvedValue(
-      jsonResponse({ data: { address: "" } }),
-    );
+    mockFetch.mockResolvedValue(jsonResponse({ data: { address: "" } }));
 
     const result = await resolveNameService("nobody.osmo", env, CHAINS);
     expect(result).toBeNull();
@@ -219,13 +249,17 @@ describe("TON DNS resolution", () => {
 
   it("resolves .ton name via tonapi.io", async () => {
     mockFetch.mockResolvedValue(
-      jsonResponse({ wallet: { address: "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2" } }),
+      jsonResponse({
+        wallet: { address: "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2" },
+      }),
     );
 
     const result = await resolveNameService("wallet.ton", env, CHAINS);
     expect(result).not.toBeNull();
     expect(result!.resolvedName).toBe("wallet.ton");
-    expect(result!.resolvedAddress).toBe("EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2");
+    expect(result!.resolvedAddress).toBe(
+      "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2",
+    );
   });
 
   it("returns null when not found", async () => {
@@ -244,14 +278,17 @@ describe("SuiNS resolution", () => {
       jsonResponse({
         jsonrpc: "2.0",
         id: 1,
-        result: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        result:
+          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
       }),
     );
 
     const result = await resolveNameService("myname.sui", env, CHAINS);
     expect(result).not.toBeNull();
     expect(result!.resolvedName).toBe("myname.sui");
-    expect(result!.resolvedAddress).toBe("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+    expect(result!.resolvedAddress).toBe(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    );
   });
 
   it("returns null when result is null", async () => {
@@ -269,13 +306,18 @@ describe("Aptos Names resolution", () => {
 
   it("resolves .apt name via aptosnames.com", async () => {
     mockFetch.mockResolvedValue(
-      jsonResponse({ address: "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" }),
+      jsonResponse({
+        address:
+          "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+      }),
     );
 
     const result = await resolveNameService("alice.apt", env, CHAINS);
     expect(result).not.toBeNull();
     expect(result!.resolvedName).toBe("alice.apt");
-    expect(result!.resolvedAddress).toBe("0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
+    expect(result!.resolvedAddress).toBe(
+      "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    );
   });
 
   it("returns null when not found", async () => {
@@ -290,7 +332,11 @@ describe("error handling", () => {
   it("returns null gracefully on fetch failure", async () => {
     mockFetch.mockRejectedValue(new Error("Network error"));
 
-    const result = await resolveNameService("vitalik.eth", { ALCHEMY_API_KEY: "key" }, CHAINS);
+    const result = await resolveNameService(
+      "vitalik.eth",
+      { ALCHEMY_API_KEY: "key" },
+      CHAINS,
+    );
     expect(result).toBeNull();
   });
 

--- a/worker/src/resolve.ts
+++ b/worker/src/resolve.ts
@@ -3,7 +3,14 @@ import { Chain, Env, getResolvedRpcUrls } from "./chains";
 
 // --- Name service detection ---
 
-export type NameService = "ens" | "sns" | "spaceid" | "icns" | "tondns" | "suins" | "aptosnames";
+export type NameService =
+  | "ens"
+  | "sns"
+  | "spaceid"
+  | "icns"
+  | "tondns"
+  | "suins"
+  | "aptosnames";
 
 export interface NameDetection {
   service: NameService;
@@ -55,7 +62,12 @@ function namehash(name: string): string {
 }
 
 function bytesToHex(bytes: Uint8Array): string {
-  return "0x" + Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+  return (
+    "0x" +
+    Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+  );
 }
 
 // --- ENS resolver ---
@@ -64,7 +76,11 @@ const ENS_REGISTRY = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 const RESOLVER_SELECTOR = "0x0178b8bf"; // resolver(bytes32)
 const ADDR_SELECTOR = "0x3b3b57de"; // addr(bytes32)
 
-async function ethCall(rpcUrl: string, to: string, data: string): Promise<string> {
+async function ethCall(
+  rpcUrl: string,
+  to: string,
+  data: string,
+): Promise<string> {
   const resp = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -75,26 +91,41 @@ async function ethCall(rpcUrl: string, to: string, data: string): Promise<string
       params: [{ to, data }, "latest"],
     }),
   });
-  const json = (await resp.json()) as { result?: string; error?: { message: string } };
-  if (json.error || !json.result) throw new Error(json.error?.message ?? "No result");
+  const json = (await resp.json()) as {
+    result?: string;
+    error?: { message: string };
+  };
+  if (json.error || !json.result)
+    throw new Error(json.error?.message ?? "No result");
   return json.result;
 }
 
-async function resolveENS(name: string, rpcUrls: string[]): Promise<string | null> {
+async function resolveENS(
+  name: string,
+  rpcUrls: string[],
+): Promise<string | null> {
   const node = namehash(name);
   const nodeParam = node.slice(2).padStart(64, "0"); // strip 0x, pad to 32 bytes
 
   for (const rpcUrl of rpcUrls) {
     try {
       // Step 1: get resolver address from registry
-      const resolverResult = await ethCall(rpcUrl, ENS_REGISTRY, RESOLVER_SELECTOR + nodeParam);
+      const resolverResult = await ethCall(
+        rpcUrl,
+        ENS_REGISTRY,
+        RESOLVER_SELECTOR + nodeParam,
+      );
       const resolverAddr = "0x" + resolverResult.slice(-40);
 
       // Check resolver is not zero address
       if (resolverAddr === "0x" + "0".repeat(40)) return null;
 
       // Step 2: get address from resolver
-      const addrResult = await ethCall(rpcUrl, resolverAddr, ADDR_SELECTOR + nodeParam);
+      const addrResult = await ethCall(
+        rpcUrl,
+        resolverAddr,
+        ADDR_SELECTOR + nodeParam,
+      );
       const resolved = "0x" + addrResult.slice(-40);
 
       // Check resolved is not zero address
@@ -113,7 +144,9 @@ async function resolveENS(name: string, rpcUrls: string[]): Promise<string | nul
 async function resolveSNS(name: string): Promise<string | null> {
   // Strip .sol suffix for the API
   const label = name.replace(/\.sol$/i, "");
-  const resp = await fetch(`https://sns-sdk-proxy.bonfida.workers.dev/resolve/${label}`);
+  const resp = await fetch(
+    `https://sns-sdk-proxy.bonfida.workers.dev/resolve/${label}`,
+  );
   if (!resp.ok) return null;
   const json = (await resp.json()) as { result?: string; s: string };
   // The API returns { result: "base58address" } on success
@@ -126,7 +159,7 @@ async function resolveSNS(name: string): Promise<string | null> {
 
 async function resolveSpaceID(name: string): Promise<string | null> {
   const resp = await fetch(
-    `https://api.prd.space.id/v1/getAddress?tld=bnb&domain=${encodeURIComponent(name)}`
+    `https://api.prd.space.id/v1/getAddress?tld=bnb&domain=${encodeURIComponent(name)}`,
   );
   if (!resp.ok) return null;
   const json = (await resp.json()) as { code?: number; address?: string };
@@ -136,16 +169,23 @@ async function resolveSpaceID(name: string): Promise<string | null> {
 
 // --- ICNS resolver ---
 
-const ICNS_CONTRACT = "osmo1xk0s8xgktn9x5vwcgtjdceflgpasksjcll6yqzfzfj4lnq3rha4s3fwmma"; // ICNS resolver on Osmosis
+const ICNS_CONTRACT =
+  "osmo1xk0s8xgktn9x5vwcgtjdceflgpasksjcll6yqzfzfj4lnq3rha4s3fwmma"; // ICNS resolver on Osmosis
 
-async function resolveICNS(name: string, tld: string, rpcUrls: string[]): Promise<string | null> {
+async function resolveICNS(
+  name: string,
+  tld: string,
+  rpcUrls: string[],
+): Promise<string | null> {
   const label = name.replace(new RegExp(`\\.${tld}$`, "i"), "");
-  const query = btoa(JSON.stringify({ address: { name: label, bech32_prefix: tld } }));
+  const query = btoa(
+    JSON.stringify({ address: { name: label, bech32_prefix: tld } }),
+  );
 
   for (const lcdUrl of rpcUrls) {
     try {
       const resp = await fetch(
-        `${lcdUrl}/cosmwasm/wasm/v1/contract/${ICNS_CONTRACT}/smart/${query}`
+        `${lcdUrl}/cosmwasm/wasm/v1/contract/${ICNS_CONTRACT}/smart/${query}`,
       );
       if (!resp.ok) continue;
       const json = (await resp.json()) as { data?: { address?: string } };
@@ -161,7 +201,9 @@ async function resolveICNS(name: string, tld: string, rpcUrls: string[]): Promis
 // --- TON DNS resolver ---
 
 async function resolveTonDns(name: string): Promise<string | null> {
-  const resp = await fetch(`https://tonapi.io/v2/dns/${encodeURIComponent(name)}/resolve`);
+  const resp = await fetch(
+    `https://tonapi.io/v2/dns/${encodeURIComponent(name)}/resolve`,
+  );
   if (!resp.ok) return null;
   const json = (await resp.json()) as { wallet?: { address?: string } };
   const address = json.wallet?.address;
@@ -171,7 +213,10 @@ async function resolveTonDns(name: string): Promise<string | null> {
 
 // --- SuiNS resolver ---
 
-async function resolveSuiNS(name: string, rpcUrls: string[]): Promise<string | null> {
+async function resolveSuiNS(
+  name: string,
+  rpcUrls: string[],
+): Promise<string | null> {
   const label = name.replace(/\.sui$/i, "");
   for (const rpcUrl of rpcUrls) {
     try {
@@ -185,7 +230,10 @@ async function resolveSuiNS(name: string, rpcUrls: string[]): Promise<string | n
           params: [label],
         }),
       });
-      const json = (await resp.json()) as { result?: string | null; error?: { message: string } };
+      const json = (await resp.json()) as {
+        result?: string | null;
+        error?: { message: string };
+      };
       if (json.error || !json.result) return null;
       return json.result;
     } catch {
@@ -198,7 +246,9 @@ async function resolveSuiNS(name: string, rpcUrls: string[]): Promise<string | n
 // --- Aptos Names resolver ---
 
 async function resolveAptosNames(name: string): Promise<string | null> {
-  const resp = await fetch(`https://www.aptosnames.com/api/mainnet/v1/address/${encodeURIComponent(name)}`);
+  const resp = await fetch(
+    `https://www.aptosnames.com/api/mainnet/v1/address/${encodeURIComponent(name)}`,
+  );
   if (!resp.ok) return null;
   const json = (await resp.json()) as { address?: string };
   const address = json.address;

--- a/worker/src/verify.test.ts
+++ b/worker/src/verify.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { verifyResults, detectTokens, getCoinGeckoUrl, type VerifiedResult } from "./verify";
+import {
+  verifyResults,
+  detectTokens,
+  getCoinGeckoUrl,
+  type VerifiedResult,
+} from "./verify";
 import { detect, type DetectionResult } from "./detect";
 import { CHAINS, type Env } from "./chains";
 
@@ -26,27 +31,46 @@ afterEach(() => {
 });
 
 /** Route fetch by URL substring and optionally by request body content */
-function routeFetch(routes: Array<{ match: string | ((url: string, body?: string) => boolean); response: Response | (() => Response) }>) {
-  mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    const body = typeof init?.body === "string" ? init.body : undefined;
-    for (const route of routes) {
-      if (typeof route.match === "string") {
-        if (url.includes(route.match)) {
-          return typeof route.response === "function" ? route.response() : route.response;
+function routeFetch(
+  routes: Array<{
+    match: string | ((url: string, body?: string) => boolean);
+    response: Response | (() => Response);
+  }>,
+) {
+  mockFetch.mockImplementation(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const body = typeof init?.body === "string" ? init.body : undefined;
+      for (const route of routes) {
+        if (typeof route.match === "string") {
+          if (url.includes(route.match)) {
+            return typeof route.response === "function"
+              ? route.response()
+              : route.response;
+          }
+        } else if (route.match(url, body)) {
+          return typeof route.response === "function"
+            ? route.response()
+            : route.response;
         }
-      } else if (route.match(url, body)) {
-        return typeof route.response === "function" ? route.response() : route.response;
       }
-    }
-    return new Response("Not found", { status: 404 });
-  });
+      return new Response("Not found", { status: 404 });
+    },
+  );
 }
 
 // --- EVM verification ---
 
 describe("EVM verification", () => {
-  const env: Env = { ALCHEMY_API_KEY: "test-key", ETHERSCAN_API_KEY: "eth-key" };
+  const env: Env = {
+    ALCHEMY_API_KEY: "test-key",
+    ETHERSCAN_API_KEY: "eth-key",
+  };
   const addr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
 
   it("uses Portfolio API for batch EVM address verification (found)", async () => {
@@ -56,7 +80,12 @@ describe("EVM verification", () => {
         response: jsonResponse({
           data: {
             tokens: [
-              { address: addr, network: "eth-mainnet", tokenAddress: null, tokenBalance: "100" },
+              {
+                address: addr,
+                network: "eth-mainnet",
+                tokenAddress: null,
+                tokenBalance: "100",
+              },
             ],
           },
         }),
@@ -97,15 +126,19 @@ describe("EVM verification", () => {
   it("falls back to RPC for EVM chains without Alchemy (Fantom)", async () => {
     // Portfolio API returns nothing for Fantom (no alchemyNetwork)
     routeFetch([
-      { match: "api.g.alchemy.com/data/v1", response: () => jsonResponse({ data: { tokens: [] } }) },
+      {
+        match: "api.g.alchemy.com/data/v1",
+        response: () => jsonResponse({ data: { tokens: [] } }),
+      },
       {
         // Fantom falls back to RPC since it has no etherscanChainId
         match: "rpcapi.fantom.network",
-        response: () => jsonResponse({
-          jsonrpc: "2.0",
-          id: 1,
-          result: "0x1", // has balance
-        }),
+        response: () =>
+          jsonResponse({
+            jsonrpc: "2.0",
+            id: 1,
+            result: "0x1", // has balance
+          }),
       },
     ]);
 
@@ -125,7 +158,9 @@ describe("EVM verification", () => {
       },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "ethereum");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "ethereum",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -139,7 +174,9 @@ describe("EVM verification", () => {
       },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "ethereum");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "ethereum",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("not_found");
   });
@@ -152,12 +189,19 @@ describe("EVM verification", () => {
         response: jsonResponse({ status: "0", message: "NOTOK" }),
       },
       {
-        match: (url) => url.includes("alchemy.com/v2") || url.includes("publicnode"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { blockHash: "0x..." } }),
+        match: (url) =>
+          url.includes("alchemy.com/v2") || url.includes("publicnode"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { blockHash: "0x..." },
+        }),
       },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "ethereum");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "ethereum",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -171,10 +215,15 @@ describe("Bitcoin verification", () => {
   it("tx found → ok response", async () => {
     const txHash = "a".repeat(64);
     routeFetch([
-      { match: "mempool.space/api/tx/", response: new Response("tx data", { status: 200 }) },
+      {
+        match: "mempool.space/api/tx/",
+        response: new Response("tx data", { status: 200 }),
+      },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "bitcoin");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "bitcoin",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -182,10 +231,15 @@ describe("Bitcoin verification", () => {
   it("tx not found → 404", async () => {
     const txHash = "a".repeat(64);
     routeFetch([
-      { match: "mempool.space/api/tx/", response: new Response("", { status: 404 }) },
+      {
+        match: "mempool.space/api/tx/",
+        response: new Response("", { status: 404 }),
+      },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "bitcoin");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "bitcoin",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("not_found");
   });
@@ -195,7 +249,10 @@ describe("Bitcoin verification", () => {
     routeFetch([
       {
         match: "mempool.space/api/address/",
-        response: jsonResponse({ chain_stats: { tx_count: 5 }, mempool_stats: { tx_count: 0 } }),
+        response: jsonResponse({
+          chain_stats: { tx_count: 5 },
+          mempool_stats: { tx_count: 0 },
+        }),
       },
     ]);
 
@@ -219,14 +276,23 @@ describe("Cosmos verification", () => {
         response: new Response("{}", { status: 200 }),
       },
       // All others 404
-      { match: (url) => url.includes("/cosmos/tx"), response: new Response("", { status: 404 }) },
+      {
+        match: (url) => url.includes("/cosmos/tx"),
+        response: new Response("", { status: 404 }),
+      },
       // Address/balance checks for non-tx matches
-      { match: (url) => url.includes("/cosmos/auth") || url.includes("/cosmos/bank"), response: new Response("{}", { status: 404 }) },
+      {
+        match: (url) =>
+          url.includes("/cosmos/auth") || url.includes("/cosmos/bank"),
+        response: new Response("{}", { status: 404 }),
+      },
       // Other RPCs
       { match: (url) => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "cosmos");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "cosmos",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -276,7 +342,9 @@ describe("Cosmos verification", () => {
       },
     ]);
 
-    const detections = detect(denom, CHAINS).filter((d) => d.chain.id === "cosmos");
+    const detections = detect(denom, CHAINS).filter(
+      (d) => d.chain.id === "cosmos",
+    );
     const results = await verifyResults(denom, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -298,7 +366,9 @@ describe("Tron verification", () => {
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "tron");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "tron",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -327,8 +397,13 @@ describe("Solana verification", () => {
     const sig = "5" + "A".repeat(84);
     routeFetch([
       {
-        match: (url, body) => url.includes("mainnet-beta") && !!body?.includes("getTransaction"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { slot: 123 } }),
+        match: (url, body) =>
+          url.includes("mainnet-beta") && !!body?.includes("getTransaction"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { slot: 123 },
+        }),
       },
     ]);
 
@@ -342,7 +417,11 @@ describe("Solana verification", () => {
     routeFetch([
       {
         match: (url, body) => !!body?.includes("getAccountInfo"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { value: { lamports: 1000 } } }),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { value: { lamports: 1000 } },
+        }),
       },
     ]);
 
@@ -356,7 +435,11 @@ describe("Solana verification", () => {
     routeFetch([
       {
         match: (url, body) => !!body?.includes("getAccountInfo"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { value: null } }),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { value: null },
+        }),
       },
     ]);
 
@@ -375,14 +458,21 @@ describe("Sui verification", () => {
   it("tx found via sui_getTransactionBlock", async () => {
     routeFetch([
       {
-        match: (url, body) => url.includes("sui") && !!body?.includes("sui_getTransactionBlock"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { digest: hash } }),
+        match: (url, body) =>
+          url.includes("sui") && !!body?.includes("sui_getTransactionBlock"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { digest: hash },
+        }),
       },
       // Other chains
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(hash, CHAINS).filter((d) => d.chain.id === "sui" && d.inputType === "transaction");
+    const detections = detect(hash, CHAINS).filter(
+      (d) => d.chain.id === "sui" && d.inputType === "transaction",
+    );
     const results = await verifyResults(hash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -390,12 +480,19 @@ describe("Sui verification", () => {
   it("address with balance via suix_getBalance", async () => {
     routeFetch([
       {
-        match: (url, body) => url.includes("sui") && !!body?.includes("suix_getBalance"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { totalBalance: "1000" } }),
+        match: (url, body) =>
+          url.includes("sui") && !!body?.includes("suix_getBalance"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { totalBalance: "1000" },
+        }),
       },
     ]);
 
-    const detections = detect(hash, CHAINS).filter((d) => d.chain.id === "sui" && d.inputType === "address");
+    const detections = detect(hash, CHAINS).filter(
+      (d) => d.chain.id === "sui" && d.inputType === "address",
+    );
     const results = await verifyResults(hash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -403,12 +500,19 @@ describe("Sui verification", () => {
   it("address with zero balance → not_found", async () => {
     routeFetch([
       {
-        match: (url, body) => url.includes("sui") && !!body?.includes("suix_getBalance"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { totalBalance: "0" } }),
+        match: (url, body) =>
+          url.includes("sui") && !!body?.includes("suix_getBalance"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { totalBalance: "0" },
+        }),
       },
     ]);
 
-    const detections = detect(hash, CHAINS).filter((d) => d.chain.id === "sui" && d.inputType === "address");
+    const detections = detect(hash, CHAINS).filter(
+      (d) => d.chain.id === "sui" && d.inputType === "address",
+    );
     const results = await verifyResults(hash, detections, env);
     expect(results[0].status).toBe("not_found");
   });
@@ -429,7 +533,9 @@ describe("Aptos verification", () => {
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(hash, CHAINS).filter((d) => d.chain.id === "aptos" && d.inputType === "transaction");
+    const detections = detect(hash, CHAINS).filter(
+      (d) => d.chain.id === "aptos" && d.inputType === "transaction",
+    );
     const results = await verifyResults(hash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -437,12 +543,15 @@ describe("Aptos verification", () => {
   it("address with sequence_number > 0 → found", async () => {
     routeFetch([
       {
-        match: (url) => url.includes("/accounts/") && !url.includes("transactions"),
+        match: (url) =>
+          url.includes("/accounts/") && !url.includes("transactions"),
         response: jsonResponse({ sequence_number: "5" }),
       },
     ]);
 
-    const detections = detect(hash, CHAINS).filter((d) => d.chain.id === "aptos" && d.inputType === "address");
+    const detections = detect(hash, CHAINS).filter(
+      (d) => d.chain.id === "aptos" && d.inputType === "address",
+    );
     const results = await verifyResults(hash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -450,12 +559,15 @@ describe("Aptos verification", () => {
   it("address with sequence_number 0 → not_found", async () => {
     routeFetch([
       {
-        match: (url) => url.includes("/accounts/") && !url.includes("transactions"),
+        match: (url) =>
+          url.includes("/accounts/") && !url.includes("transactions"),
         response: jsonResponse({ sequence_number: "0" }),
       },
     ]);
 
-    const detections = detect(hash, CHAINS).filter((d) => d.chain.id === "aptos" && d.inputType === "address");
+    const detections = detect(hash, CHAINS).filter(
+      (d) => d.chain.id === "aptos" && d.inputType === "address",
+    );
     const results = await verifyResults(hash, detections, env);
     expect(results[0].status).toBe("not_found");
   });
@@ -472,7 +584,9 @@ describe("TON verification", () => {
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "ton");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "ton",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("not_found");
   });
@@ -482,7 +596,10 @@ describe("TON verification", () => {
     routeFetch([
       {
         match: "getAddressInformation",
-        response: jsonResponse({ ok: true, result: { balance: "1000", state: "active" } }),
+        response: jsonResponse({
+          ok: true,
+          result: { balance: "1000", state: "active" },
+        }),
       },
     ]);
 
@@ -496,7 +613,10 @@ describe("TON verification", () => {
     routeFetch([
       {
         match: "getAddressInformation",
-        response: jsonResponse({ ok: true, result: { balance: "0", state: "uninitialized" } }),
+        response: jsonResponse({
+          ok: true,
+          result: { balance: "0", state: "uninitialized" },
+        }),
       },
     ]);
 
@@ -517,7 +637,9 @@ describe("Polkadot verification", () => {
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "polkadot");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "polkadot",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("not_found");
   });
@@ -527,7 +649,11 @@ describe("Polkadot verification", () => {
     routeFetch([
       {
         match: (url, body) => !!body?.includes("system_account"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { nonce: 5, data: { free: "0" } } }),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { nonce: 5, data: { free: "0" } },
+        }),
       },
     ]);
 
@@ -546,18 +672,26 @@ describe("NEAR verification", () => {
     const txHash = "a".repeat(64);
     routeFetch([
       {
-        match: (url, body) => url.includes("near.org") && !!body?.includes("EXPERIMENTAL_tx_status"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { status: {} } }),
+        match: (url, body) =>
+          url.includes("near.org") &&
+          !!body?.includes("EXPERIMENTAL_tx_status"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { status: {} },
+        }),
       },
     ]);
 
     // 64-hex is detected as NEAR address, so manually construct a tx detection
     const nearChain = CHAINS.find((c) => c.id === "near")!;
-    const detections: DetectionResult[] = [{
-      chain: nearChain,
-      inputType: "transaction",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: nearChain,
+        inputType: "transaction",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -566,8 +700,13 @@ describe("NEAR verification", () => {
     const addr = "alice.near";
     routeFetch([
       {
-        match: (url, body) => url.includes("near.org") && !!body?.includes("view_account"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { amount: "1000" } }),
+        match: (url, body) =>
+          url.includes("near.org") && !!body?.includes("view_account"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { amount: "1000" },
+        }),
       },
     ]);
 
@@ -583,11 +722,13 @@ describe("Monero verification", () => {
   it("always returns unverified (privacy chain)", async () => {
     const addr = "4" + "A".repeat(94);
     const moneroChain = CHAINS.find((c) => c.id === "monero")!;
-    const detections: DetectionResult[] = [{
-      chain: moneroChain,
-      inputType: "address",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: moneroChain,
+        inputType: "address",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(addr, detections, {});
     expect(results[0].status).toBe("unverified");
   });
@@ -602,18 +743,21 @@ describe("XRP verification", () => {
     const txHash = "a".repeat(64);
     routeFetch([
       {
-        match: (url, body) => url.includes("ripple.com") && !!body?.includes('"tx"'),
+        match: (url, body) =>
+          url.includes("ripple.com") && !!body?.includes('"tx"'),
         response: jsonResponse({ result: { status: "success", hash: txHash } }),
       },
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
     const xrpChain = CHAINS.find((c) => c.id === "xrp")!;
-    const detections: DetectionResult[] = [{
-      chain: xrpChain,
-      inputType: "transaction",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: xrpChain,
+        inputType: "transaction",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -622,7 +766,8 @@ describe("XRP verification", () => {
     const addr = "rN7n3473SaZBCG4dFL83w7p1W9cgPJxtfR";
     routeFetch([
       {
-        match: (url, body) => url.includes("ripple.com") && !!body?.includes("account_info"),
+        match: (url, body) =>
+          url.includes("ripple.com") && !!body?.includes("account_info"),
         response: jsonResponse({ result: { account_data: { Sequence: 5 } } }),
       },
     ]);
@@ -649,11 +794,13 @@ describe("Stellar verification", () => {
     ]);
 
     const stellarChain = CHAINS.find((c) => c.id === "stellar")!;
-    const detections: DetectionResult[] = [{
-      chain: stellarChain,
-      inputType: "transaction",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: stellarChain,
+        inputType: "transaction",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -693,11 +840,13 @@ describe("Bittensor verification", () => {
   it("always returns unverified (no free API)", async () => {
     const addr = "5" + "F".repeat(47);
     const taoChain = CHAINS.find((c) => c.id === "bittensor")!;
-    const detections: DetectionResult[] = [{
-      chain: taoChain,
-      inputType: "address",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: taoChain,
+        inputType: "address",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(addr, detections, {});
     expect(results[0].status).toBe("unverified");
   });
@@ -740,18 +889,21 @@ describe("Cardano verification", () => {
     const txHash = "a".repeat(64);
     routeFetch([
       {
-        match: (url, body) => url.includes("koios.rest") && !!body?.includes("_tx_hashes"),
+        match: (url, body) =>
+          url.includes("koios.rest") && !!body?.includes("_tx_hashes"),
         response: jsonResponse([{ tx_hash: txHash }]),
       },
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
     const cardanoChain = CHAINS.find((c) => c.id === "cardano")!;
-    const detections: DetectionResult[] = [{
-      chain: cardanoChain,
-      inputType: "transaction",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: cardanoChain,
+        inputType: "transaction",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -765,11 +917,16 @@ describe("Dogecoin verification", () => {
   it("tx found via BlockCypher", async () => {
     const txHash = "a".repeat(64);
     routeFetch([
-      { match: "blockcypher.com/v1/doge/main/txs/", response: new Response("{}", { status: 200 }) },
+      {
+        match: "blockcypher.com/v1/doge/main/txs/",
+        response: new Response("{}", { status: 200 }),
+      },
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "dogecoin");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "dogecoin",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -777,7 +934,10 @@ describe("Dogecoin verification", () => {
   it("address with n_tx > 0 → found", async () => {
     const addr = "DH5yaieqoZN36fDVciNyRueRGvGLR3mr7L";
     routeFetch([
-      { match: "blockcypher.com/v1/doge/main/addrs/", response: jsonResponse({ n_tx: 5 }) },
+      {
+        match: "blockcypher.com/v1/doge/main/addrs/",
+        response: jsonResponse({ n_tx: 5 }),
+      },
     ]);
 
     const detections = detect(addr, CHAINS);
@@ -794,11 +954,16 @@ describe("Litecoin verification", () => {
   it("tx found via BlockCypher", async () => {
     const txHash = "a".repeat(64);
     routeFetch([
-      { match: "blockcypher.com/v1/ltc/main/txs/", response: new Response("{}", { status: 200 }) },
+      {
+        match: "blockcypher.com/v1/ltc/main/txs/",
+        response: new Response("{}", { status: 200 }),
+      },
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "litecoin");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "litecoin",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -806,7 +971,10 @@ describe("Litecoin verification", () => {
   it("address with n_tx > 0 → found", async () => {
     const addr = "LaMT348PWRnrqeeWArpwQPbuanpXDZGEUz";
     routeFetch([
-      { match: "blockcypher.com/v1/ltc/main/addrs/", response: jsonResponse({ n_tx: 3 }) },
+      {
+        match: "blockcypher.com/v1/ltc/main/addrs/",
+        response: jsonResponse({ n_tx: 3 }),
+      },
     ]);
 
     const detections = detect(addr, CHAINS);
@@ -830,7 +998,9 @@ describe("Bitcoin Cash verification", () => {
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "bitcoin-cash");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "bitcoin-cash",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -840,7 +1010,9 @@ describe("Bitcoin Cash verification", () => {
     routeFetch([
       {
         match: "blockchair.com/bitcoin-cash/dashboards/address/",
-        response: jsonResponse({ data: { [addr]: { address: { transaction_count: 10 } } } }),
+        response: jsonResponse({
+          data: { [addr]: { address: { transaction_count: 10 } } },
+        }),
       },
     ]);
 
@@ -865,7 +1037,9 @@ describe("ZCash verification", () => {
       { match: () => true, response: new Response("", { status: 404 }) },
     ]);
 
-    const detections = detect(txHash, CHAINS).filter((d) => d.chain.id === "zcash");
+    const detections = detect(txHash, CHAINS).filter(
+      (d) => d.chain.id === "zcash",
+    );
     const results = await verifyResults(txHash, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -875,7 +1049,9 @@ describe("ZCash verification", () => {
     routeFetch([
       {
         match: "blockchair.com/zcash/dashboards/address/",
-        response: jsonResponse({ data: { [addr]: { address: { transaction_count: 2 } } } }),
+        response: jsonResponse({
+          data: { [addr]: { address: { transaction_count: 2 } } },
+        }),
       },
     ]);
 
@@ -894,17 +1070,21 @@ describe("Hyperliquid Core verification", () => {
   it("address found via clearinghouseState", async () => {
     routeFetch([
       {
-        match: (url, body) => url.includes("hyperliquid.xyz/info") && !!body?.includes("clearinghouseState"),
+        match: (url, body) =>
+          url.includes("hyperliquid.xyz/info") &&
+          !!body?.includes("clearinghouseState"),
         response: jsonResponse({ marginSummary: { accountValue: "1000.0" } }),
       },
     ]);
 
     const coreChain = CHAINS.find((c) => c.id === "hyperliquid-core")!;
-    const detections: DetectionResult[] = [{
-      chain: coreChain,
-      inputType: "address",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: coreChain,
+        inputType: "address",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(addr, detections, env);
     expect(results[0].status).toBe("found");
   });
@@ -912,17 +1092,21 @@ describe("Hyperliquid Core verification", () => {
   it("address with zero account value → not_found", async () => {
     routeFetch([
       {
-        match: (url, body) => url.includes("hyperliquid.xyz/info") && !!body?.includes("clearinghouseState"),
+        match: (url, body) =>
+          url.includes("hyperliquid.xyz/info") &&
+          !!body?.includes("clearinghouseState"),
         response: jsonResponse({ marginSummary: { accountValue: "0.0" } }),
       },
     ]);
 
     const coreChain = CHAINS.find((c) => c.id === "hyperliquid-core")!;
-    const detections: DetectionResult[] = [{
-      chain: coreChain,
-      inputType: "address",
-      explorerUrls: [],
-    }];
+    const detections: DetectionResult[] = [
+      {
+        chain: coreChain,
+        inputType: "address",
+        explorerUrls: [],
+      },
+    ];
     const results = await verifyResults(addr, detections, env);
     expect(results[0].status).toBe("not_found");
   });
@@ -937,12 +1121,21 @@ describe("tryEndpoints failover", () => {
     let callCount = 0;
 
     mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
       callCount++;
       if (url.includes("helius")) throw new Error("Connection refused");
       if (url.includes("alchemy")) throw new Error("Connection refused");
       // Public endpoint succeeds
-      return jsonResponse({ jsonrpc: "2.0", id: 1, result: { value: { lamports: 1000 } } });
+      return jsonResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { value: { lamports: 1000 } },
+      });
     });
 
     const detections = detect(addr, CHAINS);
@@ -971,16 +1164,27 @@ describe("detectTokens", () => {
     routeFetch([
       {
         match: (url, body) => !!body?.includes("alchemy_getTokenMetadata"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { decimals: 6, name: "USDC", symbol: "USDC" } }),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { decimals: 6, name: "USDC", symbol: "USDC" },
+        }),
       },
       {
         match: (url, body) => !!body?.includes("eth_call"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: "0x0000000000000000000000000000000000000000000000000000000000000006" }),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result:
+            "0x0000000000000000000000000000000000000000000000000000000000000006",
+        }),
       },
     ]);
 
     const detections = detect(addr, CHAINS);
-    const tokenChains = await detectTokens(addr, detections, { ALCHEMY_API_KEY: "key" });
+    const tokenChains = await detectTokens(addr, detections, {
+      ALCHEMY_API_KEY: "key",
+    });
     expect(tokenChains.has("ethereum")).toBe(true);
   });
 
@@ -989,13 +1193,23 @@ describe("detectTokens", () => {
     routeFetch([
       {
         // Fantom has no Alchemy, uses eth_call fallback
-        match: (url, body) => url.includes("fantom") && !!body?.includes("eth_call"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: "0x0000000000000000000000000000000000000000000000000000000000000012" }),
+        match: (url, body) =>
+          url.includes("fantom") && !!body?.includes("eth_call"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result:
+            "0x0000000000000000000000000000000000000000000000000000000000000012",
+        }),
       },
       {
         // Other Alchemy chains - no token metadata
         match: (url, body) => !!body?.includes("alchemy_getTokenMetadata"),
-        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: { decimals: null } }),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { decimals: null },
+        }),
       },
     ]);
 
@@ -1012,7 +1226,9 @@ describe("detectTokens", () => {
         response: jsonResponse({
           jsonrpc: "2.0",
           id: 1,
-          result: { value: { owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" } },
+          result: {
+            value: { owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" },
+          },
         }),
       },
     ]);
@@ -1071,7 +1287,10 @@ describe("getCoinGeckoUrl", () => {
   it("returns null on 404", async () => {
     const addr = "0x" + "f".repeat(40);
     routeFetch([
-      { match: "api.coingecko.com", response: new Response("", { status: 404 }) },
+      {
+        match: "api.coingecko.com",
+        response: new Response("", { status: 404 }),
+      },
     ]);
 
     const detections = detect(addr, CHAINS);
@@ -1083,7 +1302,12 @@ describe("getCoinGeckoUrl", () => {
     const addr = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
     const calls: string[] = [];
     mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
       calls.push(url);
       return jsonResponse({ id: "usd-coin", web_slug: "usd-coin" });
     });

--- a/worker/src/verify.ts
+++ b/worker/src/verify.ts
@@ -19,7 +19,10 @@ const REQUEST_TIMEOUT_MS = 6000;
 
 // --- Endpoint failover ---
 
-async function tryEndpoints(rpcUrls: string[], verifyFn: (url: string) => Promise<boolean>): Promise<boolean> {
+async function tryEndpoints(
+  rpcUrls: string[],
+  verifyFn: (url: string) => Promise<boolean>,
+): Promise<boolean> {
   for (const url of rpcUrls) {
     try {
       return await verifyFn(url);
@@ -39,27 +42,61 @@ async function etherscanV2Call(
   params: Record<string, string>,
   apiKey: string,
 ): Promise<unknown> {
-  const qs = new URLSearchParams({ chainid: String(chainId), module, action, apikey: apiKey, ...params });
+  const qs = new URLSearchParams({
+    chainid: String(chainId),
+    module,
+    action,
+    apikey: apiKey,
+    ...params,
+  });
   const response = await fetch(`https://api.etherscan.io/v2/api?${qs}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
-  const json = (await response.json()) as { status?: string; message?: string; result?: unknown };
+  const json = (await response.json()) as {
+    status?: string;
+    message?: string;
+    result?: unknown;
+  };
   // Etherscan returns status "0" for errors (e.g. unsupported chain on free plan)
   if (json.status === "0") throw new Error(`Etherscan error: ${json.message}`);
   return json.result;
 }
 
-async function verifyEvmTxEtherscan(chainId: number, txHash: string, apiKey: string): Promise<boolean> {
-  const result = await etherscanV2Call(chainId, "proxy", "eth_getTransactionReceipt", { txhash: txHash }, apiKey);
+async function verifyEvmTxEtherscan(
+  chainId: number,
+  txHash: string,
+  apiKey: string,
+): Promise<boolean> {
+  const result = await etherscanV2Call(
+    chainId,
+    "proxy",
+    "eth_getTransactionReceipt",
+    { txhash: txHash },
+    apiKey,
+  );
   return result != null;
 }
 
-async function verifyEvmAddrEtherscan(chainId: number, address: string, apiKey: string): Promise<boolean> {
+async function verifyEvmAddrEtherscan(
+  chainId: number,
+  address: string,
+  apiKey: string,
+): Promise<boolean> {
   const [balance, nonce] = await Promise.all([
-    etherscanV2Call(chainId, "proxy", "eth_getBalance", { address, tag: "latest" }, apiKey) as Promise<string | null>,
-    etherscanV2Call(chainId, "proxy", "eth_getTransactionCount", { address, tag: "latest" }, apiKey) as Promise<
-      string | null
-    >,
+    etherscanV2Call(
+      chainId,
+      "proxy",
+      "eth_getBalance",
+      { address, tag: "latest" },
+      apiKey,
+    ) as Promise<string | null>,
+    etherscanV2Call(
+      chainId,
+      "proxy",
+      "eth_getTransactionCount",
+      { address, tag: "latest" },
+      apiKey,
+    ) as Promise<string | null>,
   ]);
   const hasBalance = balance != null && balance !== "0x0" && balance !== "0x";
   const hasNonce = nonce != null && nonce !== "0x0" && nonce !== "0x";
@@ -68,7 +105,11 @@ async function verifyEvmAddrEtherscan(chainId: number, address: string, apiKey: 
 
 // --- Direct JSON-RPC helpers ---
 
-async function evmRpcCall(rpcUrl: string, method: string, params: unknown[]): Promise<unknown> {
+async function evmRpcCall(
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+): Promise<unknown> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -79,15 +120,28 @@ async function evmRpcCall(rpcUrl: string, method: string, params: unknown[]): Pr
   return json.result;
 }
 
-async function verifyEvmTxRpc(rpcUrl: string, txHash: string): Promise<boolean> {
-  const result = await evmRpcCall(rpcUrl, "eth_getTransactionReceipt", [txHash]);
+async function verifyEvmTxRpc(
+  rpcUrl: string,
+  txHash: string,
+): Promise<boolean> {
+  const result = await evmRpcCall(rpcUrl, "eth_getTransactionReceipt", [
+    txHash,
+  ]);
   return result != null;
 }
 
-async function verifyEvmAddrRpc(rpcUrl: string, address: string): Promise<boolean> {
+async function verifyEvmAddrRpc(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
   const [balance, nonce] = await Promise.all([
-    evmRpcCall(rpcUrl, "eth_getBalance", [address, "latest"]) as Promise<string | null>,
-    evmRpcCall(rpcUrl, "eth_getTransactionCount", [address, "latest"]) as Promise<string | null>,
+    evmRpcCall(rpcUrl, "eth_getBalance", [address, "latest"]) as Promise<
+      string | null
+    >,
+    evmRpcCall(rpcUrl, "eth_getTransactionCount", [
+      address,
+      "latest",
+    ]) as Promise<string | null>,
   ]);
   const hasBalance = balance != null && balance !== "0x0" && balance !== "0x";
   const hasNonce = nonce != null && nonce !== "0x0" && nonce !== "0x";
@@ -96,14 +150,20 @@ async function verifyEvmAddrRpc(rpcUrl: string, address: string): Promise<boolea
 
 // --- Bitcoin ---
 
-async function verifyBitcoinTx(apiUrl: string, txHash: string): Promise<boolean> {
+async function verifyBitcoinTx(
+  apiUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/tx/${txHash}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   return response.ok;
 }
 
-async function verifyBitcoinAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyBitcoinAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/address/${address}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -119,14 +179,20 @@ async function verifyBitcoinAddr(apiUrl: string, address: string): Promise<boole
 
 // --- Cosmos ---
 
-async function verifyCosmosTx(restUrl: string, txHash: string): Promise<boolean> {
+async function verifyCosmosTx(
+  restUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(`${restUrl}/cosmos/tx/v1beta1/txs/${txHash}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   return response.ok;
 }
 
-async function verifyCosmosAddr(restUrl: string, address: string): Promise<boolean> {
+async function verifyCosmosAddr(
+  restUrl: string,
+  address: string,
+): Promise<boolean> {
   // Check if account exists (has sequence > 0 or has balances)
   const [acctRes, balRes] = await Promise.all([
     fetch(`${restUrl}/cosmos/auth/v1beta1/accounts/${address}`, {
@@ -142,14 +208,22 @@ async function verifyCosmosAddr(restUrl: string, address: string): Promise<boole
   }
   if (balRes.ok) {
     const bal = (await balRes.json()) as { balances?: { amount?: string }[] };
-    if (bal.balances && bal.balances.length > 0 && bal.balances.some((b) => b.amount !== "0")) return true;
+    if (
+      bal.balances &&
+      bal.balances.length > 0 &&
+      bal.balances.some((b) => b.amount !== "0")
+    )
+      return true;
   }
   return false;
 }
 
 // --- Cosmos denom ---
 
-async function verifyCosmosDenom(restUrl: string, denom: string): Promise<boolean> {
+async function verifyCosmosDenom(
+  restUrl: string,
+  denom: string,
+): Promise<boolean> {
   const response = await fetch(
     `${restUrl}/cosmos/bank/v1beta1/supply/by_denom?denom=${encodeURIComponent(denom)}`,
     { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
@@ -172,7 +246,10 @@ async function verifyTronTx(apiUrl: string, txHash: string): Promise<boolean> {
   return !!json.txID;
 }
 
-async function verifyTronAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyTronAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/wallet/getaccount`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -180,13 +257,20 @@ async function verifyTronAddr(apiUrl: string, address: string): Promise<boolean>
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) return false;
-  const json = (await response.json()) as { address?: string; balance?: number };
+  const json = (await response.json()) as {
+    address?: string;
+    balance?: number;
+  };
   return !!json.address;
 }
 
 // --- Solana ---
 
-async function solanaRpcCall(rpcUrl: string, method: string, params: unknown[]): Promise<unknown> {
+async function solanaRpcCall(
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+): Promise<unknown> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -198,13 +282,25 @@ async function solanaRpcCall(rpcUrl: string, method: string, params: unknown[]):
   return json.result;
 }
 
-async function verifySolanaTx(rpcUrl: string, signature: string): Promise<boolean> {
-  const result = await solanaRpcCall(rpcUrl, "getTransaction", [signature, { encoding: "json", maxSupportedTransactionVersion: 0 }]);
+async function verifySolanaTx(
+  rpcUrl: string,
+  signature: string,
+): Promise<boolean> {
+  const result = await solanaRpcCall(rpcUrl, "getTransaction", [
+    signature,
+    { encoding: "json", maxSupportedTransactionVersion: 0 },
+  ]);
   return result != null;
 }
 
-async function verifySolanaAddr(rpcUrl: string, address: string): Promise<boolean> {
-  const result = (await solanaRpcCall(rpcUrl, "getAccountInfo", [address, { encoding: "base64" }])) as {
+async function verifySolanaAddr(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
+  const result = (await solanaRpcCall(rpcUrl, "getAccountInfo", [
+    address,
+    { encoding: "base64" },
+  ])) as {
     value?: { lamports?: number } | null;
   } | null;
   return result?.value != null;
@@ -212,7 +308,11 @@ async function verifySolanaAddr(rpcUrl: string, address: string): Promise<boolea
 
 // --- Sui ---
 
-async function suiRpcCall(rpcUrl: string, method: string, params: unknown[]): Promise<unknown> {
+async function suiRpcCall(
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+): Promise<unknown> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -225,11 +325,17 @@ async function suiRpcCall(rpcUrl: string, method: string, params: unknown[]): Pr
 }
 
 async function verifySuiTx(rpcUrl: string, digest: string): Promise<boolean> {
-  const result = await suiRpcCall(rpcUrl, "sui_getTransactionBlock", [digest, { showInput: false }]);
+  const result = await suiRpcCall(rpcUrl, "sui_getTransactionBlock", [
+    digest,
+    { showInput: false },
+  ]);
   return result != null;
 }
 
-async function verifySuiAddr(rpcUrl: string, address: string): Promise<boolean> {
+async function verifySuiAddr(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
   const result = (await suiRpcCall(rpcUrl, "suix_getBalance", [address])) as {
     totalBalance?: string;
   } | null;
@@ -245,7 +351,10 @@ async function verifyAptosTx(apiUrl: string, txHash: string): Promise<boolean> {
   return response.ok;
 }
 
-async function verifyAptosAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyAptosAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/accounts/${address}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -263,12 +372,21 @@ async function verifyTonTx(apiUrl: string, txHash: string): Promise<boolean> {
   return false;
 }
 
-async function verifyTonAddr(apiUrl: string, address: string): Promise<boolean> {
-  const response = await fetch(`${apiUrl}/getAddressInformation?address=${encodeURIComponent(address)}`, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+async function verifyTonAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
+  const response = await fetch(
+    `${apiUrl}/getAddressInformation?address=${encodeURIComponent(address)}`,
+    {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
   if (!response.ok) return false;
-  const json = (await response.json()) as { ok?: boolean; result?: { balance?: string; state?: string } };
+  const json = (await response.json()) as {
+    ok?: boolean;
+    result?: { balance?: string; state?: string };
+  };
   if (!json.ok) return false;
   const state = json.result?.state;
   return state === "active" || state === "frozen";
@@ -276,31 +394,52 @@ async function verifyTonAddr(apiUrl: string, address: string): Promise<boolean> 
 
 // --- Polkadot ---
 
-async function verifyPolkadotTx(rpcUrl: string, _txHash: string): Promise<boolean> {
+async function verifyPolkadotTx(
+  rpcUrl: string,
+  _txHash: string,
+): Promise<boolean> {
   // Substrate RPCs don't support tx lookup by hash without an indexer
   return false;
 }
 
-async function verifyPolkadotAddr(rpcUrl: string, address: string): Promise<boolean> {
+async function verifyPolkadotAddr(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
   // Use Substrate RPC system.account to check if an account has balance/nonce
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "system_account", params: [address] }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "system_account",
+      params: [address],
+    }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   // This won't work with the simple publicnode HTTP endpoint, so fall back to unverified
   if (!response.ok) return false;
-  const json = (await response.json()) as { result?: { nonce?: number; data?: { free?: string } }; error?: unknown };
+  const json = (await response.json()) as {
+    result?: { nonce?: number; data?: { free?: string } };
+    error?: unknown;
+  };
   if (json.error || !json.result) return false;
   const nonce = json.result.nonce ?? 0;
   const free = json.result.data?.free ?? "0";
-  return nonce > 0 || (free !== "0" && free !== "0x0000000000000000000000000000000000");
+  return (
+    nonce > 0 ||
+    (free !== "0" && free !== "0x0000000000000000000000000000000000")
+  );
 }
 
 // --- NEAR ---
 
-async function nearRpcCall(rpcUrl: string, method: string, params: Record<string, unknown>): Promise<unknown> {
+async function nearRpcCall(
+  rpcUrl: string,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -314,11 +453,17 @@ async function nearRpcCall(rpcUrl: string, method: string, params: Record<string
 
 async function verifyNearTx(rpcUrl: string, txHash: string): Promise<boolean> {
   // NEAR tx query requires sender_id which we don't have — use EXPERIMENTAL_tx_status
-  const result = await nearRpcCall(rpcUrl, "EXPERIMENTAL_tx_status", { tx_hash: txHash, wait_until: "NONE" });
+  const result = await nearRpcCall(rpcUrl, "EXPERIMENTAL_tx_status", {
+    tx_hash: txHash,
+    wait_until: "NONE",
+  });
   return result != null;
 }
 
-async function verifyNearAddr(rpcUrl: string, accountId: string): Promise<boolean> {
+async function verifyNearAddr(
+  rpcUrl: string,
+  accountId: string,
+): Promise<boolean> {
   const result = (await nearRpcCall(rpcUrl, "query", {
     request_type: "view_account",
     finality: "final",
@@ -414,14 +559,22 @@ async function verifyEvmAddrsBatch(
 const SPL_TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
 
-async function detectEvmTokenAlchemy(alchemyUrl: string, address: string): Promise<boolean> {
-  const result = (await evmRpcCall(alchemyUrl, "alchemy_getTokenMetadata", [address])) as {
+async function detectEvmTokenAlchemy(
+  alchemyUrl: string,
+  address: string,
+): Promise<boolean> {
+  const result = (await evmRpcCall(alchemyUrl, "alchemy_getTokenMetadata", [
+    address,
+  ])) as {
     decimals?: number | null;
   } | null;
   return result?.decimals != null;
 }
 
-async function detectEvmTokenFallback(rpcUrl: string, address: string): Promise<boolean> {
+async function detectEvmTokenFallback(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
   // Call decimals() selector on the address
   const result = (await evmRpcCall(rpcUrl, "eth_call", [
     { to: address, data: "0x313ce567" },
@@ -430,7 +583,10 @@ async function detectEvmTokenFallback(rpcUrl: string, address: string): Promise<
   return result != null && result !== "0x" && result !== "0x0";
 }
 
-async function detectSolanaToken(rpcUrl: string, address: string): Promise<boolean> {
+async function detectSolanaToken(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
   const result = (await solanaRpcCall(rpcUrl, "getAccountInfo", [
     address,
     { encoding: "jsonParsed" },
@@ -496,7 +652,9 @@ export async function getCoinGeckoUrl(
 
   const withPlatform = detections
     .filter((d) => d.chain.coingeckoPlatformId)
-    .sort((a, b) => (a.chain.id === "ethereum" ? -1 : b.chain.id === "ethereum" ? 1 : 0));
+    .sort((a, b) =>
+      a.chain.id === "ethereum" ? -1 : b.chain.id === "ethereum" ? 1 : 0,
+    );
 
   for (const detection of withPlatform) {
     try {
@@ -504,7 +662,10 @@ export async function getCoinGeckoUrl(
       const resp = await fetch(
         `https://api.coingecko.com/api/v3/coins/${platformId}/contract/${address.toLowerCase()}`,
         {
-          headers: { "Accept": "application/json", "User-Agent": "crypto-lookup-worker/1.0" },
+          headers: {
+            Accept: "application/json",
+            "User-Agent": "crypto-lookup-worker/1.0",
+          },
           signal: AbortSignal.timeout(4000),
         },
       );
@@ -521,25 +682,37 @@ export async function getCoinGeckoUrl(
 
 // --- BlockCypher (Dogecoin, Litecoin) ---
 
-async function verifyBlockCypherTx(apiUrl: string, txHash: string): Promise<boolean> {
+async function verifyBlockCypherTx(
+  apiUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/txs/${txHash}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   return response.ok;
 }
 
-async function verifyBlockCypherAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyBlockCypherAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/addrs/${address}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) return false;
-  const json = (await response.json()) as { n_tx?: number; total_received?: number };
+  const json = (await response.json()) as {
+    n_tx?: number;
+    total_received?: number;
+  };
   return (json.n_tx ?? 0) > 0;
 }
 
 // --- Blockchair (Bitcoin Cash, ZCash) ---
 
-async function verifyBlockchairTx(apiUrl: string, txHash: string): Promise<boolean> {
+async function verifyBlockchairTx(
+  apiUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/dashboards/transaction/${txHash}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -548,12 +721,17 @@ async function verifyBlockchairTx(apiUrl: string, txHash: string): Promise<boole
   return json.data != null && Object.keys(json.data).length > 0;
 }
 
-async function verifyBlockchairAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyBlockchairAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/dashboards/address/${address}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) return false;
-  const json = (await response.json()) as { data?: Record<string, { address?: { transaction_count?: number } }> };
+  const json = (await response.json()) as {
+    data?: Record<string, { address?: { transaction_count?: number } }>;
+  };
   if (!json.data) return false;
   const addrData = Object.values(json.data)[0];
   return (addrData?.address?.transaction_count ?? 0) > 0;
@@ -561,14 +739,20 @@ async function verifyBlockchairAddr(apiUrl: string, address: string): Promise<bo
 
 // --- XRP Ledger ---
 
-async function xrpRpcCall(rpcUrl: string, method: string, params: unknown[]): Promise<unknown> {
+async function xrpRpcCall(
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+): Promise<unknown> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ method, params }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
-  const json = (await response.json()) as { result?: { status?: string; [key: string]: unknown } };
+  const json = (await response.json()) as {
+    result?: { status?: string; [key: string]: unknown };
+  };
   if (!json.result || json.result.status === "error") return null;
   return json.result;
 }
@@ -578,8 +762,13 @@ async function verifyXrpTx(rpcUrl: string, txHash: string): Promise<boolean> {
   return result != null;
 }
 
-async function verifyXrpAddr(rpcUrl: string, address: string): Promise<boolean> {
-  const result = (await xrpRpcCall(rpcUrl, "account_info", [{ account: address }])) as {
+async function verifyXrpAddr(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
+  const result = (await xrpRpcCall(rpcUrl, "account_info", [
+    { account: address },
+  ])) as {
     account_data?: { Sequence?: number };
   } | null;
   return result?.account_data != null;
@@ -587,14 +776,20 @@ async function verifyXrpAddr(rpcUrl: string, address: string): Promise<boolean> 
 
 // --- Stellar ---
 
-async function verifyStellarTx(apiUrl: string, txHash: string): Promise<boolean> {
+async function verifyStellarTx(
+  apiUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/transactions/${txHash}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   return response.ok;
 }
 
-async function verifyStellarAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyStellarAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/accounts/${address}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -603,16 +798,25 @@ async function verifyStellarAddr(apiUrl: string, address: string): Promise<boole
 
 // --- Cardano ---
 
-async function verifyCardanoAddr(apiUrl: string, address: string): Promise<boolean> {
-  const response = await fetch(`${apiUrl}/address_info?_address=${encodeURIComponent(address)}`, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+async function verifyCardanoAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
+  const response = await fetch(
+    `${apiUrl}/address_info?_address=${encodeURIComponent(address)}`,
+    {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
   if (!response.ok) return false;
   const json = (await response.json()) as Array<{ balance?: string }>;
   return Array.isArray(json) && json.length > 0;
 }
 
-async function verifyCardanoTx(apiUrl: string, txHash: string): Promise<boolean> {
+async function verifyCardanoTx(
+  apiUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/tx_info`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -626,7 +830,10 @@ async function verifyCardanoTx(apiUrl: string, txHash: string): Promise<boolean>
 
 // --- Lightning Network ---
 
-async function verifyLightningNode(apiUrl: string, pubkey: string): Promise<boolean> {
+async function verifyLightningNode(
+  apiUrl: string,
+  pubkey: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/nodes/${pubkey}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -635,7 +842,10 @@ async function verifyLightningNode(apiUrl: string, pubkey: string): Promise<bool
 
 // --- Hyperliquid Core ---
 
-async function verifyHyperliquidCoreAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyHyperliquidCoreAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   // Check perps and spot balances in parallel
   const [perpsRes, spotRes] = await Promise.all([
     fetch(apiUrl, {
@@ -653,13 +863,17 @@ async function verifyHyperliquidCoreAddr(apiUrl: string, address: string): Promi
   ]);
 
   if (perpsRes.ok) {
-    const json = (await perpsRes.json()) as { marginSummary?: { accountValue?: string } };
+    const json = (await perpsRes.json()) as {
+      marginSummary?: { accountValue?: string };
+    };
     const val = json.marginSummary?.accountValue;
     if (val != null && val !== "0" && val !== "0.0") return true;
   }
 
   if (spotRes.ok) {
-    const json = (await spotRes.json()) as { balances?: Array<{ total?: string }> };
+    const json = (await spotRes.json()) as {
+      balances?: Array<{ total?: string }>;
+    };
     if (Array.isArray(json.balances) && json.balances.length > 0) return true;
   }
 
@@ -668,11 +882,19 @@ async function verifyHyperliquidCoreAddr(apiUrl: string, address: string): Promi
 
 // --- Filecoin ---
 
-async function verifyFilecoinAddr(rpcUrl: string, address: string): Promise<boolean> {
+async function verifyFilecoinAddr(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "Filecoin.StateGetActor", params: [address, null] }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "Filecoin.StateGetActor",
+      params: [address, null],
+    }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   const json = (await response.json()) as { result?: unknown; error?: unknown };
@@ -683,7 +905,12 @@ async function verifyFilecoinTx(rpcUrl: string, cid: string): Promise<boolean> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "Filecoin.ChainGetMessage", params: [{ "/": cid }] }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "Filecoin.ChainGetMessage",
+      params: [{ "/": cid }],
+    }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   const json = (await response.json()) as { result?: unknown; error?: unknown };
@@ -692,7 +919,10 @@ async function verifyFilecoinTx(rpcUrl: string, cid: string): Promise<boolean> {
 
 // --- Hedera ---
 
-async function verifyHederaAddr(apiUrl: string, accountId: string): Promise<boolean> {
+async function verifyHederaAddr(
+  apiUrl: string,
+  accountId: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/api/v1/accounts/${accountId}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -708,7 +938,10 @@ async function verifyHederaTx(apiUrl: string, txId: string): Promise<boolean> {
 
 // --- Kaspa ---
 
-async function verifyKaspaAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyKaspaAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/addresses/${address}/balance`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -724,14 +957,20 @@ async function verifyKaspaTx(apiUrl: string, txHash: string): Promise<boolean> {
 
 // --- Algorand ---
 
-async function verifyAlgorandAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyAlgorandAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/v2/accounts/${address}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   return response.ok;
 }
 
-async function verifyAlgorandTx(apiUrl: string, txId: string): Promise<boolean> {
+async function verifyAlgorandTx(
+  apiUrl: string,
+  txId: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/v2/transactions/${txId}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -740,14 +979,20 @@ async function verifyAlgorandTx(apiUrl: string, txId: string): Promise<boolean> 
 
 // --- MultiversX ---
 
-async function verifyMultiversXAddr(apiUrl: string, address: string): Promise<boolean> {
+async function verifyMultiversXAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/accounts/${address}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   return response.ok;
 }
 
-async function verifyMultiversXTx(apiUrl: string, txHash: string): Promise<boolean> {
+async function verifyMultiversXTx(
+  apiUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(`${apiUrl}/transactions/${txHash}`, {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
@@ -756,22 +1001,38 @@ async function verifyMultiversXTx(apiUrl: string, txHash: string): Promise<boole
 
 // --- Starknet ---
 
-async function verifyStarknetAddr(rpcUrl: string, address: string): Promise<boolean> {
+async function verifyStarknetAddr(
+  rpcUrl: string,
+  address: string,
+): Promise<boolean> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "starknet_getNonce", params: ["latest", address] }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "starknet_getNonce",
+      params: ["latest", address],
+    }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   const json = (await response.json()) as { result?: unknown; error?: unknown };
   return json.result != null && !json.error;
 }
 
-async function verifyStarknetTx(rpcUrl: string, txHash: string): Promise<boolean> {
+async function verifyStarknetTx(
+  rpcUrl: string,
+  txHash: string,
+): Promise<boolean> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "starknet_getTransactionByHash", params: [txHash] }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "starknet_getTransactionByHash",
+      params: [txHash],
+    }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   const json = (await response.json()) as { result?: unknown; error?: unknown };
@@ -780,13 +1041,21 @@ async function verifyStarknetTx(rpcUrl: string, txHash: string): Promise<boolean
 
 // --- Stacks ---
 
-async function verifyStacksAddr(apiUrl: string, address: string): Promise<boolean> {
-  const response = await fetch(`${apiUrl}/extended/v1/address/${address}/balances`, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+async function verifyStacksAddr(
+  apiUrl: string,
+  address: string,
+): Promise<boolean> {
+  const response = await fetch(
+    `${apiUrl}/extended/v1/address/${address}/balances`,
+    {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    },
+  );
   if (!response.ok) return false;
-  const json = (await response.json()) as { stx?: { total_sent?: string; total_received?: string } };
-  return (json.stx?.total_sent !== "0" || json.stx?.total_received !== "0");
+  const json = (await response.json()) as {
+    stx?: { total_sent?: string; total_received?: string };
+  };
+  return json.stx?.total_sent !== "0" || json.stx?.total_received !== "0";
 }
 
 async function verifyStacksTx(apiUrl: string, txId: string): Promise<boolean> {
@@ -800,23 +1069,43 @@ async function verifyStacksTx(apiUrl: string, txId: string): Promise<boolean> {
 
 // --- Nockchain ---
 
-async function verifyNockchainAddr(rpcUrl: string, address: string, apiKey: string): Promise<boolean> {
+async function verifyNockchainAddr(
+  rpcUrl: string,
+  address: string,
+  apiKey: string,
+): Promise<boolean> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json", "x-api-key": apiKey },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransactionsByAddress", params: [{ address }] }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getTransactionsByAddress",
+      params: [{ address }],
+    }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) return false;
-  const json = (await response.json()) as { result?: { totalTransactions?: number } };
+  const json = (await response.json()) as {
+    result?: { totalTransactions?: number };
+  };
   return (json.result?.totalTransactions ?? 0) > 0;
 }
 
-async function verifyNockchainTx(rpcUrl: string, txId: string, apiKey: string): Promise<boolean> {
+async function verifyNockchainTx(
+  rpcUrl: string,
+  txId: string,
+  apiKey: string,
+): Promise<boolean> {
   const response = await fetch(rpcUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json", "x-api-key": apiKey },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "getTransactionByTxid", params: [{ transactionId: txId }] }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getTransactionByTxid",
+      params: [{ transactionId: txId }],
+    }),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) return false;
@@ -826,14 +1115,27 @@ async function verifyNockchainTx(rpcUrl: string, txId: string, apiKey: string): 
 
 // --- Main verification ---
 
-async function verifyEvm(chain: Chain, inputType: string, input: string, env: Env): Promise<boolean> {
+async function verifyEvm(
+  chain: Chain,
+  inputType: string,
+  input: string,
+  env: Env,
+): Promise<boolean> {
   // Try Etherscan V2 first
   if (chain.etherscanChainId && env.ETHERSCAN_API_KEY) {
     try {
       if (inputType === "transaction") {
-        return await verifyEvmTxEtherscan(chain.etherscanChainId, input, env.ETHERSCAN_API_KEY);
+        return await verifyEvmTxEtherscan(
+          chain.etherscanChainId,
+          input,
+          env.ETHERSCAN_API_KEY,
+        );
       } else {
-        return await verifyEvmAddrEtherscan(chain.etherscanChainId, input, env.ETHERSCAN_API_KEY);
+        return await verifyEvmAddrEtherscan(
+          chain.etherscanChainId,
+          input,
+          env.ETHERSCAN_API_KEY,
+        );
       }
     } catch {
       // Etherscan failed (unsupported chain, rate limit, etc.) — fall through to RPC
@@ -853,7 +1155,11 @@ async function verifyEvm(chain: Chain, inputType: string, input: string, env: En
   });
 }
 
-async function verifySingle(result: DetectionResult, input: string, env: Env): Promise<VerificationStatus> {
+async function verifySingle(
+  result: DetectionResult,
+  input: string,
+  env: Env,
+): Promise<VerificationStatus> {
   const { chain, inputType } = result;
   const isTx = inputType === "transaction";
   const rpcUrls = getResolvedRpcUrls(chain, env);
@@ -868,7 +1174,9 @@ async function verifySingle(result: DetectionResult, input: string, env: Env): P
       case "evm":
         // HyperCore uses a custom API, not standard EVM RPC
         if (chain.id === "hyperliquid-core" && inputType === "address") {
-          found = await tryEndpoints(rpcUrls, (url) => verifyHyperliquidCoreAddr(url, input));
+          found = await tryEndpoints(rpcUrls, (url) =>
+            verifyHyperliquidCoreAddr(url, input),
+          );
           break;
         }
         found = await verifyEvm(chain, inputType, input, env);
@@ -883,7 +1191,9 @@ async function verifySingle(result: DetectionResult, input: string, env: Env): P
         found = await tryEndpoints(rpcUrls, (url) =>
           inputType === "denom"
             ? verifyCosmosDenom(url, input)
-            : isTx ? verifyCosmosTx(url, input) : verifyCosmosAddr(url, input),
+            : isTx
+              ? verifyCosmosTx(url, input)
+              : verifyCosmosAddr(url, input),
         );
         break;
       case "tron":
@@ -924,18 +1234,24 @@ async function verifySingle(result: DetectionResult, input: string, env: Env): P
       case "dogecoin":
       case "litecoin":
         found = await tryEndpoints(rpcUrls, (url) =>
-          isTx ? verifyBlockCypherTx(url, input) : verifyBlockCypherAddr(url, input),
+          isTx
+            ? verifyBlockCypherTx(url, input)
+            : verifyBlockCypherAddr(url, input),
         );
         break;
       case "bitcoincash":
       case "zcash":
         found = await tryEndpoints(rpcUrls, (url) =>
-          isTx ? verifyBlockchairTx(url, input) : verifyBlockchairAddr(url, input),
+          isTx
+            ? verifyBlockchairTx(url, input)
+            : verifyBlockchairAddr(url, input),
         );
         break;
       case "lightning":
         if (inputType === "address") {
-          found = await tryEndpoints(rpcUrls, (url) => verifyLightningNode(url, input));
+          found = await tryEndpoints(rpcUrls, (url) =>
+            verifyLightningNode(url, input),
+          );
           break;
         }
         return "unverified";
@@ -958,7 +1274,11 @@ async function verifySingle(result: DetectionResult, input: string, env: Env): P
         if (!env.NOCKBLOCKS_API_KEY) return "unverified";
         found = isTx
           ? await verifyNockchainTx(rpcUrls[0], input, env.NOCKBLOCKS_API_KEY)
-          : await verifyNockchainAddr(rpcUrls[0], input, env.NOCKBLOCKS_API_KEY);
+          : await verifyNockchainAddr(
+              rpcUrls[0],
+              input,
+              env.NOCKBLOCKS_API_KEY,
+            );
         break;
       case "xrp":
         found = await tryEndpoints(rpcUrls, (url) =>
@@ -997,7 +1317,9 @@ async function verifySingle(result: DetectionResult, input: string, env: Env): P
         break;
       case "multiversx":
         found = await tryEndpoints(rpcUrls, (url) =>
-          isTx ? verifyMultiversXTx(url, input) : verifyMultiversXAddr(url, input),
+          isTx
+            ? verifyMultiversXTx(url, input)
+            : verifyMultiversXAddr(url, input),
         );
         break;
       case "starknet":
@@ -1031,9 +1353,10 @@ export async function verifyResults(
   );
 
   // Batch-verify EVM addresses via Portfolio API
-  const batchStatuses = evmAddrDetections.length > 0
-    ? await verifyEvmAddrsBatch(trimmed, evmAddrDetections, env)
-    : new Map<string, VerificationStatus>();
+  const batchStatuses =
+    evmAddrDetections.length > 0
+      ? await verifyEvmAddrsBatch(trimmed, evmAddrDetections, env)
+      : new Map<string, VerificationStatus>();
 
   // For EVM addresses not covered by batch (Fantom, API failure), fall back to verifySingle
   const evmFallbacks = evmAddrDetections.filter(
@@ -1058,7 +1381,10 @@ export async function verifyResults(
     family: r.chain.family,
     inputType: r.inputType,
     explorerUrls: r.explorerUrls,
-    status: batchStatuses.get(r.chain.id) ?? singleStatuses.get(r.chain.id) ?? "unverified",
+    status:
+      batchStatuses.get(r.chain.id) ??
+      singleStatuses.get(r.chain.id) ??
+      "unverified",
     ...(r.chain.isTestnet && { isTestnet: true }),
   }));
 }


### PR DESCRIPTION
## Summary
Ran `prettier --write` across the whole codebase (raycast, website, worker) for consistent formatting.

- **Pure formatting** — quotes, line-wrapping, multi-line JSX/CSS selectors. No logic changes.
- Added `.prettierignore` (skips build output, lockfiles, `.claude/`).
- Restored the exec-bit on three website source files back to `644`.

## Verification
- `vite build` (website) — ✅ builds, identical output asset hashes
- `vitest run` (worker) — ✅ 273/273 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)