### PR TITLE
Security hardening for public release

### DIFF
--- a/raycast/README.md
+++ b/raycast/README.md
@@ -17,6 +17,17 @@ Paste any crypto address or transaction hash to instantly detect the chain and o
 2. Paste an address, transaction hash, or name (e.g. `vitalik.eth`)
 3. Press Enter to open the result in a block explorer
 
+## Privacy
+
+The address, transaction hash, or name you enter is sent to the Multiscan lookup
+service ([multiscan.dev](https://multiscan.dev), or your own Worker URL in
+preferences) to detect the chain, resolve names, and verify on-chain activity.
+Nothing is sent until you type or paste a query.
+
+Clipboard auto-fill is **off by default**. If you enable it in preferences, the
+extension reads your clipboard on launch and, when it looks like an address,
+looks it up automatically — so only turn it on if you're comfortable with that.
+
 ## Powered by
 
 [multiscan.dev](https://multiscan.dev) — the open-source multi-chain lookup engine.

--- a/raycast/package.json
+++ b/raycast/package.json
@@ -28,6 +28,15 @@
       "required": true
     },
     {
+      "name": "autoFillFromClipboard",
+      "title": "Clipboard",
+      "label": "Auto-fill search from clipboard on open",
+      "description": "When enabled, the clipboard contents are read on launch and, if they look like an address, sent to the lookup service automatically. Off by default so unrelated copied text is never sent without your action.",
+      "type": "checkbox",
+      "default": false,
+      "required": false
+    },
+    {
       "name": "explorerEthereum",
       "title": "Ethereum Explorer",
       "description": "Base URL for Ethereum block explorer",

--- a/raycast/src/search.tsx
+++ b/raycast/src/search.tsx
@@ -106,10 +106,24 @@ export default function SearchCommand(props: LaunchProps) {
   const [nameNotFound, setNameNotFound] = useState(false);
   const [coinGeckoUrl, setCoinGeckoUrl] = useState<string | null>(null);
 
-  const { data: clipboardText } = usePromise(async () => {
-    const clip = await Clipboard.readText();
-    return clip?.trim() ?? "";
-  });
+  const prefs = getPreferenceValues<{
+    workerUrl: string;
+    autoFillFromClipboard?: boolean;
+  }>();
+  const workerUrl = prefs.workerUrl;
+
+  // Clipboard auto-fill is opt-in: it reads the clipboard and triggers a lookup
+  // (which sends the contents to the worker) without explicit user action, so it
+  // is off by default to avoid sending unrelated copied data — e.g. a private key
+  // or token — off-device. Only read the clipboard when the user enables it.
+  const { data: clipboardText } = usePromise(
+    async () => {
+      const clip = await Clipboard.readText();
+      return clip?.trim() ?? "";
+    },
+    [],
+    { execute: prefs.autoFillFromClipboard === true },
+  );
 
   // Auto-fill from clipboard on launch (skip if launched via fallback)
   useEffect(() => {
@@ -124,9 +138,6 @@ export default function SearchCommand(props: LaunchProps) {
       }
     }
   }, [clipboardText]);
-
-  const prefs = getPreferenceValues<{ workerUrl: string }>();
-  const workerUrl = prefs.workerUrl;
 
   const explorerOverrides = useMemo(() => getExplorerOverrides(), []);
 

--- a/worker/src/chains.ts
+++ b/worker/src/chains.ts
@@ -68,18 +68,27 @@ export interface Chain {
   isTestnet?: boolean;
 }
 
+/** Cloudflare Workers rate-limiting binding (configured in wrangler.toml). */
+export interface RateLimiter {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
 export interface Env {
   ETHERSCAN_API_KEY?: string;
   ALCHEMY_API_KEY?: string;
   HELIUS_API_KEY?: string;
   NOCKBLOCKS_API_KEY?: string;
+  GITHUB_TOKEN?: string;
+  // Rate-limiting bindings. Optional so local dev / tests run without them.
+  LOOKUP_RATE_LIMITER?: RateLimiter;
+  SUGGEST_RATE_LIMITER?: RateLimiter;
 }
 
 /** Replace {key} placeholder with the actual secret value. Returns null if key is required but missing. */
 export function resolveRpcUrl(endpoint: RpcEndpoint, env: Env): string | null {
   if (!endpoint.keyEnvVar) return endpoint.url;
   const key = env[endpoint.keyEnvVar as keyof Env];
-  if (!key) return null;
+  if (typeof key !== "string" || !key) return null;
   return endpoint.url.replace("{key}", key);
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,4 +1,4 @@
-import { CHAINS, Env } from "./chains";
+import { CHAINS, Env, RateLimiter } from "./chains";
 import { detect } from "./detect";
 import { resolveNameService } from "./resolve";
 import { checkExistingSuggestion, createSuggestion } from "./suggest";
@@ -24,6 +24,44 @@ function jsonResponse(data: unknown, status = 200): Response {
   });
 }
 
+// Anti-DoS guard: longest legitimate input (a Cardano Byron address) is ~110
+// chars. 512 leaves generous headroom for future long formats while rejecting
+// oversized payloads. Per-format length is already enforced by detection regexes.
+const MAX_INPUT_LENGTH = 512;
+const MAX_NETWORK_NAME_LENGTH = 100;
+const MAX_DESCRIPTION_LENGTH = 1000;
+
+/** Per-client key for rate limiting, derived from Cloudflare's connecting IP. */
+function clientKey(request: Request): string {
+  return request.headers.get("CF-Connecting-IP") ?? "unknown";
+}
+
+/**
+ * Returns true if the request should be blocked. Fails open when the binding is
+ * absent (local dev / tests) or the limiter errors, so availability is never
+ * worse than today.
+ */
+async function isRateLimited(
+  limiter: RateLimiter | undefined,
+  key: string,
+): Promise<boolean> {
+  if (!limiter) return false;
+  try {
+    const { success } = await limiter.limit({ key });
+    return !success;
+  } catch {
+    return false;
+  }
+}
+
+/** Collapse to a single line and cap length — used for the GitHub issue title. */
+function sanitizeNetworkName(raw: string): string {
+  return raw
+    .replace(/[\r\n\t]+/g, " ")
+    .trim()
+    .slice(0, MAX_NETWORK_NAME_LENGTH);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     // Handle CORS preflight
@@ -35,9 +73,12 @@ export default {
 
     // POST /api/suggest/check — check for existing network suggestions
     if (url.pathname === "/api/suggest/check" && request.method === "POST") {
+      if (await isRateLimited(env.SUGGEST_RATE_LIMITER, clientKey(request))) {
+        return jsonResponse({ error: "Too many requests" }, 429);
+      }
       try {
         const body = (await request.json()) as { networkName?: string };
-        const networkName = (body.networkName ?? "").trim();
+        const networkName = sanitizeNetworkName(body.networkName ?? "");
         if (!networkName) {
           return jsonResponse({ error: "Missing networkName" }, 400);
         }
@@ -50,18 +91,24 @@ export default {
 
     // POST /api/suggest/create — create a new suggestion or upvote existing
     if (url.pathname === "/api/suggest/create" && request.method === "POST") {
+      if (await isRateLimited(env.SUGGEST_RATE_LIMITER, clientKey(request))) {
+        return jsonResponse({ error: "Too many requests" }, 429);
+      }
       try {
         const body = (await request.json()) as {
           networkName?: string;
           description?: string;
         };
-        const networkName = (body.networkName ?? "").trim();
+        const networkName = sanitizeNetworkName(body.networkName ?? "");
         if (!networkName) {
           return jsonResponse({ error: "Missing networkName" }, 400);
         }
+        const description = (body.description ?? "")
+          .trim()
+          .slice(0, MAX_DESCRIPTION_LENGTH);
         const result = await createSuggestion(
           networkName,
-          body.description,
+          description || undefined,
           env,
         );
         return jsonResponse(result);
@@ -73,6 +120,10 @@ export default {
     // Only accept POST /api/lookup
     if (url.pathname !== "/api/lookup" || request.method !== "POST") {
       return jsonResponse({ error: "POST /api/lookup expected" }, 404);
+    }
+
+    if (await isRateLimited(env.LOOKUP_RATE_LIMITER, clientKey(request))) {
+      return jsonResponse({ error: "Too many requests" }, 429);
     }
 
     let input: string;
@@ -90,6 +141,10 @@ export default {
 
     if (!input) {
       return jsonResponse({ error: "Missing input" }, 400);
+    }
+
+    if (input.length > MAX_INPUT_LENGTH) {
+      return jsonResponse({ error: "Input too long" }, 400);
     }
 
     // Try name resolution first (e.g. vitalik.eth → 0x...)

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -11,7 +11,22 @@ routes = [
 directory = "./dist"
 not_found_handling = "single-page-application"
 
+# Rate limiting, keyed per connecting IP (period must be 10 or 60).
+# Lookup: generous — it's the core read path.
+[[ratelimits]]
+name = "LOOKUP_RATE_LIMITER"
+namespace_id = "1001"
+simple = { limit = 60, period = 10 }
+
+# Suggest: strict — it creates GitHub issues via a server-side token.
+[[ratelimits]]
+name = "SUGGEST_RATE_LIMITER"
+namespace_id = "1002"
+simple = { limit = 5, period = 60 }
+
 # Secrets (set via `wrangler secret put <NAME>`):
 # ETHERSCAN_API_KEY
 # ALCHEMY_API_KEY
 # HELIUS_API_KEY
+# NOCKBLOCKS_API_KEY
+# GITHUB_TOKEN  (fine-grained: Issues read/write on sunnya97/multiscan only)


### PR DESCRIPTION
Addresses the findings from the pre-release security review.

## Worker
- **Input cap** — reject `/api/lookup` input over 512 chars (anti-DoS payload guard; per-format length is still enforced by detection regexes).
- **Rate limiting** — per-connecting-IP Cloudflare rate-limit bindings on `/api/lookup` (60 / 10s) and `/api/suggest/*` (5 / 60s). Protects the owner's paid Alchemy/Etherscan/Helius keys from abuse and throttles the unauthenticated GitHub-issue-creating endpoint. Bindings **fail open** when absent, so local dev and tests are unaffected.
- **Suggest hardening** — `networkName` is collapsed to a single line and capped at 100 chars (prevents issue-title injection); `description` capped at 1000.
- `GITHUB_TOKEN` documented in `wrangler.toml` as fine-grained, Issues-only on this repo.

## Raycast extension
- **Clipboard auto-fill is now opt-in (default off).** Previously the extension read the clipboard on launch and auto-sent anything ≥20 chars matching `[a-zA-Z0-9._:-]` to the worker — which matches private keys and JWTs. Now nothing is read/sent without explicit user action. Added a privacy section to the README.

## Verification
- `tsc --noEmit` — clean (worker + extension)
- `vitest run` (worker) — 273/273 pass
- `ray lint` — package.json, icons, and metadata validate ✅

## Not included (need provisioned credentials / out of scope)
- **Turnstile** on the suggest form — needs a Cloudflare Turnstile site/secret key I can't provision; rate limiting + length caps already close the main abuse vector. Happy to wire it up if you create the keys.
- **Pre-existing:** `ray lint` ESLint step fails because the repo has no ESLint config file — unrelated to this PR, but worth fixing before store submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)