### PR TITLE
Add ESLint config so ray lint passes

### DIFF
--- a/raycast/.eslintrc.json
+++ b/raycast/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["@raycast"]
+}

--- a/raycast/src/search.tsx
+++ b/raycast/src/search.tsx
@@ -131,7 +131,7 @@ export default function SearchCommand(props: LaunchProps) {
       const clip = clipboardText.trim();
       // Accept long addresses/hashes OR short name-service inputs
       if (
-        (clip.length >= 20 && /^[a-zA-Z0-9._:\-]+$/.test(clip)) ||
+        (clip.length >= 20 && /^[a-zA-Z0-9._:-]+$/.test(clip)) ||
         isNameInput(clip)
       ) {
         setSearchText(clip);
@@ -367,7 +367,6 @@ function ResultItem({
   coinGeckoUrl?: string | null;
 }) {
   const {
-    chainId,
     chainName,
     symbol,
     inputType,


### PR DESCRIPTION
## Summary
The Raycast extension had **no ESLint config file**, so `ray lint` errored out (`ESLint couldn't find a configuration file`) — which blocks a clean Raycast Store submission.

- Add `raycast/.eslintrc.json` extending `@raycast` (the installed `@raycast/eslint-config@1.0.11` is eslintrc-style, using `@rushstack/eslint-patch` + `@typescript-eslint@6`).
- Fix the two pre-existing errors ESLint surfaced in `search.tsx`:
  - Remove an unnecessary escape (`\-` inside a character class).
  - Drop an unused `chainId` destructured binding.

## Result
`ray lint` now passes (manifest, icons, metadata, ESLint, Prettier all green). One non-blocking title-case **warning** remains on the `Open in CoinGecko` action — intentionally kept to preserve the correct brand capitalization.

## Note
`ray lint` uses Raycast's bundled ESLint 8.57.1 (eslintrc mode), which is why the eslintrc format is correct here rather than flat config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)