### PR TITLE
Add Turnstile bot protection to network suggestion form

### DIFF
--- a/website/src/App.css
+++ b/website/src/App.css
@@ -1018,6 +1018,11 @@ body {
   border-color: var(--accent);
 }
 
+.suggest-modal__turnstile {
+  margin-bottom: 14px;
+  min-height: 65px;
+}
+
 .suggest-modal__actions {
   display: flex;
   gap: 8px;

--- a/website/src/components/SuggestNetwork.tsx
+++ b/website/src/components/SuggestNetwork.tsx
@@ -1,4 +1,29 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+// Public Turnstile site key (safe to embed). The matching secret is set as the
+// worker's TURNSTILE_SECRET; verification is only enforced when that is present.
+const TURNSTILE_SITE_KEY = "0x4AAAAAADs-QWgnebCfpxy0";
+const TURNSTILE_SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+interface TurnstileApi {
+  render(
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      callback: (token: string) => void;
+      "error-callback"?: () => void;
+      "expired-callback"?: () => void;
+    },
+  ): string;
+  remove(widgetId: string): void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
 
 interface SuggestNetworkProps {
   onClose: () => void;
@@ -17,6 +42,49 @@ export default function SuggestNetwork({ onClose }: SuggestNetworkProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [result, setResult] = useState<SuggestResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const [turnstileError, setTurnstileError] = useState(false);
+  const turnstileRef = useRef<HTMLDivElement>(null);
+
+  // Render the Turnstile widget. Loads the script once, then renders explicitly.
+  useEffect(() => {
+    let widgetId: string | undefined;
+
+    const renderWidget = () => {
+      if (!turnstileRef.current || !window.turnstile || widgetId) return;
+      widgetId = window.turnstile.render(turnstileRef.current, {
+        sitekey: TURNSTILE_SITE_KEY,
+        callback: (token) => {
+          setTurnstileToken(token);
+          setTurnstileError(false);
+        },
+        "error-callback": () => setTurnstileError(true),
+        "expired-callback": () => setTurnstileToken(null),
+      });
+    };
+
+    if (window.turnstile) {
+      renderWidget();
+      return;
+    }
+
+    let script = document.querySelector<HTMLScriptElement>(
+      'script[src^="https://challenges.cloudflare.com/turnstile"]',
+    );
+    if (!script) {
+      script = document.createElement("script");
+      script.src = TURNSTILE_SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+    }
+    script.addEventListener("load", renderWidget);
+
+    return () => {
+      script?.removeEventListener("load", renderWidget);
+      if (widgetId && window.turnstile) window.turnstile.remove(widgetId);
+    };
+  }, []);
 
   const handleSubmit = async () => {
     const trimmed = networkName.trim();
@@ -32,6 +100,7 @@ export default function SuggestNetwork({ onClose }: SuggestNetworkProps) {
         body: JSON.stringify({
           networkName: trimmed,
           description: description.trim() || undefined,
+          turnstileToken: turnstileToken ?? undefined,
         }),
       });
 
@@ -80,6 +149,7 @@ export default function SuggestNetwork({ onClose }: SuggestNetworkProps) {
               rows={3}
             />
             {error && <p className="suggest-modal__error">{error}</p>}
+            <div className="suggest-modal__turnstile" ref={turnstileRef} />
             <div className="suggest-modal__actions">
               <button
                 className="suggest-modal__btn suggest-modal__btn--secondary"
@@ -90,7 +160,11 @@ export default function SuggestNetwork({ onClose }: SuggestNetworkProps) {
               <button
                 className="suggest-modal__btn suggest-modal__btn--primary"
                 onClick={handleSubmit}
-                disabled={!networkName.trim() || isSubmitting}
+                disabled={
+                  !networkName.trim() ||
+                  isSubmitting ||
+                  (!turnstileToken && !turnstileError)
+                }
               >
                 {isSubmitting ? "Submitting..." : "Submit"}
               </button>

--- a/worker/src/chains.ts
+++ b/worker/src/chains.ts
@@ -79,6 +79,9 @@ export interface Env {
   HELIUS_API_KEY?: string;
   NOCKBLOCKS_API_KEY?: string;
   GITHUB_TOKEN?: string;
+  // Cloudflare Turnstile secret. When set, /api/suggest/create requires a valid
+  // challenge token; when absent (local dev), the check is skipped.
+  TURNSTILE_SECRET?: string;
   // Rate-limiting bindings. Optional so local dev / tests run without them.
   LOOKUP_RATE_LIMITER?: RateLimiter;
   SUGGEST_RATE_LIMITER?: RateLimiter;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -62,6 +62,29 @@ function sanitizeNetworkName(raw: string): string {
     .slice(0, MAX_NETWORK_NAME_LENGTH);
 }
 
+/** Verify a Cloudflare Turnstile token via siteverify. Returns false on any error. */
+async function verifyTurnstile(
+  token: string,
+  secret: string,
+  ip: string,
+): Promise<boolean> {
+  try {
+    const body = new URLSearchParams({
+      secret,
+      response: token,
+      remoteip: ip,
+    });
+    const resp = await fetch(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+      { method: "POST", body },
+    );
+    const data = (await resp.json()) as { success?: boolean };
+    return data.success === true;
+  } catch {
+    return false;
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     // Handle CORS preflight
@@ -98,7 +121,27 @@ export default {
         const body = (await request.json()) as {
           networkName?: string;
           description?: string;
+          turnstileToken?: string;
         };
+        // Bot protection: enforced only when a Turnstile secret is configured,
+        // so local dev (no secret) keeps working.
+        if (env.TURNSTILE_SECRET) {
+          const token =
+            typeof body.turnstileToken === "string" ? body.turnstileToken : "";
+          const ok =
+            token.length > 0 &&
+            (await verifyTurnstile(
+              token,
+              env.TURNSTILE_SECRET,
+              clientKey(request),
+            ));
+          if (!ok) {
+            return jsonResponse(
+              { error: "Challenge verification failed" },
+              403,
+            );
+          }
+        }
         const networkName = sanitizeNetworkName(body.networkName ?? "");
         if (!networkName) {
           return jsonResponse({ error: "Missing networkName" }, 400);

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -30,3 +30,4 @@ simple = { limit = 5, period = 60 }
 # HELIUS_API_KEY
 # NOCKBLOCKS_API_KEY
 # GITHUB_TOKEN  (fine-grained: Issues read/write on sunnya97/multiscan only)
+# TURNSTILE_SECRET  (Cloudflare Turnstile secret; gates /api/suggest/create)


### PR DESCRIPTION
Defense-in-depth on `/api/suggest/create` (which creates GitHub issues via a server-side token), layered on top of the rate limit added earlier.

## Website
- Renders a Cloudflare Turnstile widget in the suggest modal (explicit render, script loaded once).
- Submit is disabled until the challenge is solved (or the widget errors, e.g. on localhost).
- Sends the token as `turnstileToken` with the create request.

## Worker
- Verifies the token via Turnstile `siteverify` before creating an issue; returns 403 on failure.
- **Enforced only when `TURNSTILE_SECRET` is set**, so local dev and tests (no secret) keep working. The public site key is embedded in the frontend; the secret is a worker secret.

## Verification
- worker `tsc` clean + 273/273 tests
- website builds clean

## Activation
Enforcement turns on once `TURNSTILE_SECRET` is set on the worker (`wrangler secret put TURNSTILE_SECRET`). Until then the widget renders but verification is skipped — no broken intermediate state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)