### PR TITLE
Prep Raycast extension for store submission

### DIFF
--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Multiscan Changelog
 
-## [Initial Version] - 2026-03-09
+## [Initial Version] - {PR_MERGE_DATE}
 
 - Paste any crypto address or transaction hash to auto-detect the chain
 - Support for 70+ chains including Bitcoin, Ethereum, Solana, Cosmos ecosystem, and more

--- a/raycast/package.json
+++ b/raycast/package.json
@@ -25,7 +25,7 @@
       "description": "URL of the crypto-lookup Cloudflare Worker",
       "type": "textfield",
       "default": "https://multiscan.dev/api",
-      "required": true
+      "required": false
     },
     {
       "name": "autoFillFromClipboard",


### PR DESCRIPTION
Makes the extension ready to submit to the `raycast/extensions` store.

- **CHANGELOG** uses the `{PR_MERGE_DATE}` placeholder (Raycast replaces it on merge) instead of a hardcoded date.
- **Worker URL preference is now non-required** — it has a working default (`multiscan.dev`), so first launch no longer forces a setup screen; also pre-empts reviewer pushback on a required preference pointing at an external backend.

Validated: `ray lint` passes (0 errors). Extension is self-contained (no imports outside `raycast/src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)