### PR TITLE
Don't tag EOAs as tokens (eth_getCode guard)

### DIFF
--- a/worker/src/verify.test.ts
+++ b/worker/src/verify.test.ts
@@ -1163,6 +1163,11 @@ describe("detectTokens", () => {
     const addr = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"; // USDC
     routeFetch([
       {
+        // Token contract has bytecode
+        match: (url, body) => !!body?.includes("eth_getCode"),
+        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: "0x60806040" }),
+      },
+      {
         match: (url, body) => !!body?.includes("alchemy_getTokenMetadata"),
         response: jsonResponse({
           jsonrpc: "2.0",
@@ -1186,6 +1191,40 @@ describe("detectTokens", () => {
       ALCHEMY_API_KEY: "key",
     });
     expect(tokenChains.has("ethereum")).toBe(true);
+  });
+
+  it("does not flag an EOA as a token even if Alchemy returns default decimals", async () => {
+    // vitalik.eth resolves to an EOA (no contract code on any chain). Some chains'
+    // alchemy_getTokenMetadata returns a non-null decimals for it — the eth_getCode
+    // guard must prevent the false "token" tag.
+    const addr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    routeFetch([
+      {
+        // EOA: no bytecode
+        match: (url, body) => !!body?.includes("eth_getCode"),
+        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: "0x" }),
+      },
+      {
+        // Buggy chains still return default decimals for the EOA
+        match: (url, body) => !!body?.includes("alchemy_getTokenMetadata"),
+        response: jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { decimals: 18 },
+        }),
+      },
+      {
+        // Non-Alchemy fallback: decimals() on an EOA returns empty
+        match: (url, body) => !!body?.includes("eth_call"),
+        response: jsonResponse({ jsonrpc: "2.0", id: 1, result: "0x" }),
+      },
+    ]);
+
+    const detections = detect(addr, CHAINS);
+    const tokenChains = await detectTokens(addr, detections, {
+      ALCHEMY_API_KEY: "key",
+    });
+    expect(tokenChains.size).toBe(0);
   });
 
   it("detects EVM token via fallback (eth_call decimals) when no Alchemy", async () => {

--- a/worker/src/verify.ts
+++ b/worker/src/verify.ts
@@ -563,6 +563,16 @@ async function detectEvmTokenAlchemy(
   alchemyUrl: string,
   address: string,
 ): Promise<boolean> {
+  // An address with no bytecode is an EOA (wallet) and can never be a token.
+  // Guard against alchemy_getTokenMetadata returning default (non-null) decimals
+  // for EOAs on some chains (e.g. Gnosis, Blast, Zora, World Chain, Unichain),
+  // which produced false "token" tags for plain wallet addresses.
+  const code = (await evmRpcCall(alchemyUrl, "eth_getCode", [
+    address,
+    "latest",
+  ])) as string | null;
+  if (!code || code === "0x") return false;
+
   const result = (await evmRpcCall(alchemyUrl, "alchemy_getTokenMetadata", [
     address,
   ])) as {


### PR DESCRIPTION
## Problem
Plain wallet addresses (EOAs) like `vitalik.eth`'s were shown with a **TOKEN** tag on Gnosis, Blast, World Chain, Zora, and Unichain.

## Cause
`detectEvmTokenAlchemy` treated `alchemy_getTokenMetadata(address).decimals != null` as "is a token". On those chains Alchemy returns a **non-null default `decimals`** even for non-token/EOA addresses, so the heuristic false-positived. (Chains without Alchemy use the `decimals()` `eth_call` fallback, which correctly returns empty for EOAs — hence they were unaffected.)

Confirmed: `eth_getCode` for the address returns `0x` on Gnosis and Blast → no bytecode → it's an EOA, which categorically cannot be a token.

## Fix
Guard token detection on the address having contract bytecode (`eth_getCode !== "0x"`). Strictly correct: every ERC-20 token is a contract, so this removes false positives without ever hiding a real token. Adds a regression test (`does not flag an EOA as a token even if Alchemy returns default decimals`).

## Verification
- worker `tsc` clean
- `vitest run` — 274/274 pass (new EOA regression test included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)