### PR TITLE
Address Raycast review feedback on the extension

### DIFF
--- a/raycast/package.json
+++ b/raycast/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "multiscan",
   "title": "Multiscan",
   "description": "Multiscan — paste any crypto address or transaction hash, auto-detect the chain, and open the block explorer",

--- a/raycast/src/chains.ts
+++ b/raycast/src/chains.ts
@@ -2,7 +2,7 @@ import { getPreferenceValues } from "@raycast/api";
 
 interface ChainPreference {
   id: string;
-  preferenceName: string;
+  preferenceName: keyof Preferences;
 }
 
 const CHAIN_PREFERENCES: ChainPreference[] = [
@@ -32,12 +32,12 @@ const CHAIN_PREFERENCES: ChainPreference[] = [
 ];
 
 export function getExplorerOverrides(): Map<string, string> {
-  const prefs = getPreferenceValues<Record<string, string>>();
+  const prefs = getPreferenceValues<Preferences>();
   const overrides = new Map<string, string>();
 
   for (const chain of CHAIN_PREFERENCES) {
     const override = prefs[chain.preferenceName];
-    if (override && override.trim() !== "") {
+    if (typeof override === "string" && override.trim() !== "") {
       overrides.set(chain.id, override.trim().replace(/\/+$/, ""));
     }
   }

--- a/raycast/src/search.tsx
+++ b/raycast/src/search.tsx
@@ -47,7 +47,7 @@ function applyExplorerOverride(
       /* invalid override URL, use full pathname */
     }
     const cleanBase = overrideBaseUrl.replace(/\/+$/, "");
-    const overriddenUrl = `${cleanBase}${relativePath}${originalUrl.hash}`;
+    const overriddenUrl = `${cleanBase}${relativePath}${originalUrl.search}${originalUrl.hash}`;
     explorerUrls = [
       { name: first.name, url: overriddenUrl },
       ...explorerUrls.slice(1),
@@ -106,10 +106,7 @@ export default function SearchCommand(props: LaunchProps) {
   const [nameNotFound, setNameNotFound] = useState(false);
   const [coinGeckoUrl, setCoinGeckoUrl] = useState<string | null>(null);
 
-  const prefs = getPreferenceValues<{
-    workerUrl: string;
-    autoFillFromClipboard?: boolean;
-  }>();
+  const prefs = getPreferenceValues<Preferences>();
   const workerUrl = prefs.workerUrl;
 
   // Clipboard auto-fill is opt-in: it reads the clipboard and triggers a lookup
@@ -193,12 +190,18 @@ export default function SearchCommand(props: LaunchProps) {
 
     setVerifyingInput(trimmedSearch);
     let cancelled = false;
-    fetchWorker(phase2Input, workerUrl, true).then((resp) => {
-      if (!cancelled) {
-        setVerifiedResults(resp.results);
-        setCoinGeckoUrl(resp.coinGeckoUrl ?? null);
-      }
-    });
+    fetchWorker(phase2Input, workerUrl, true)
+      .then((resp) => {
+        if (!cancelled) {
+          setVerifiedResults(resp.results);
+          setCoinGeckoUrl(resp.coinGeckoUrl ?? null);
+        }
+      })
+      .catch(() => {
+        // Verification failed — fall back to the unverified detection results
+        // rather than leaving the UI stuck in a loading state.
+        if (!cancelled) setVerifiedResults(detectResults);
+      });
     return () => {
       cancelled = true;
     };

--- a/raycast/tsconfig.json
+++ b/raycast/tsconfig.json
@@ -19,5 +19,5 @@
     "strict": true,
     "target": "ES2022"
   },
-  "include": ["src/**/*", "env.d.ts"]
+  "include": ["src/**/*", "raycast-env.d.ts"]
 }


### PR DESCRIPTION
Fixes the 5 issues the Raycast store PR's automated reviewer (Greptile) flagged:

- **P1** `search.tsx` — phase-2 verify fetch had no `.catch()`; a network error left the UI stuck loading. Now falls back to the unverified detection results.
- **P1** `search.tsx` / `chains.ts` — use the generated `Preferences` type instead of hand-written `getPreferenceValues` annotations that can drift from `package.json`.
- **P2** `search.tsx` — `applyExplorerOverride` now preserves URL query params.
- **P2** `package.json` — added the `$schema` field.
- Also fixed `tsconfig.json` include (`env.d.ts` → `raycast-env.d.ts`) so `Preferences` resolves under bare `tsc`.

Verified: `tsc` clean, `ray lint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)