### PR TITLE
Add IPFS/IPNS support to the Raycast extension

### DIFF
--- a/raycast/CHANGELOG.md
+++ b/raycast/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Multiscan Changelog
 
+## [IPFS & IPNS support] - {PR_MERGE_DATE}
+
+- Detect IPFS content identifiers (CIDs) and IPNS names, with links to public gateways (ipfs.io, dweb.link, Pinata)
+- Supports CIDv0, CIDv1, base36 IPNS keys, and `ipfs://` / `ipns://` schemes
+
 ## [Initial Version] - {PR_MERGE_DATE}
 
 - Paste any crypto address or transaction hash to auto-detect the chain

--- a/raycast/README.md
+++ b/raycast/README.md
@@ -8,6 +8,7 @@ Paste any crypto address or transaction hash to instantly detect the chain and o
 - **70+ chains** — Bitcoin, Ethereum, Solana, Cosmos ecosystem, Sui, Aptos, Cardano, Polkadot, TON, XRP, Tron, and many more
 - **On-chain verification** — Confirms whether an address has activity on each detected chain
 - **Name resolution** — Resolves ENS (.eth), SNS (.sol), BNB (.bnb), and other name services
+- **IPFS / IPNS** — Detects content identifiers (CIDs) and IPNS names and links to public gateways
 - **Testnet support** — Detects testnet addresses and displays a Testnet badge
 - **Customizable explorers** — Override the default block explorer for any chain in preferences
 

--- a/raycast/src/chainLogos.ts
+++ b/raycast/src/chainLogos.ts
@@ -238,6 +238,10 @@ const CHAIN_LOGO_SLUG: Record<string, string> = {
 };
 
 export function getChainLogoUrl(chainName: string): string | undefined {
+  // IPFS/IPNS share a single SVG glyph (no .png slug).
+  if (chainName === "IPFS" || chainName === "IPNS") {
+    return "https://multiscan.dev/logos/ipfs.svg";
+  }
   const slug = CHAIN_LOGO_SLUG[chainName];
   if (!slug) return undefined;
   return `https://multiscan.dev/logos/${slug}.png`;

--- a/raycast/src/search.tsx
+++ b/raycast/src/search.tsx
@@ -381,13 +381,15 @@ function ResultItem({
   const typeLabel =
     inputType === "address"
       ? "Address"
-      : inputType === "validator"
-        ? "Validator"
-        : inputType === "denom"
-          ? "Denom"
-          : "Transaction";
+      : inputType === "cid"
+        ? "CID"
+        : inputType === "validator"
+          ? "Validator"
+          : inputType === "denom"
+            ? "Denom"
+            : "Transaction";
   const tagColor =
-    inputType === "address" || inputType === "validator"
+    inputType === "address" || inputType === "validator" || inputType === "cid"
       ? Color.Blue
       : Color.Green;
 

--- a/raycast/src/types.ts
+++ b/raycast/src/types.ts
@@ -1,4 +1,9 @@
-export type InputType = "address" | "transaction" | "denom" | "validator";
+export type InputType =
+  | "address"
+  | "transaction"
+  | "denom"
+  | "validator"
+  | "cid";
 
 export type VerificationStatus = "unverified" | "found" | "not_found";
 


### PR DESCRIPTION
Client-side polish so the Raycast extension renders IPFS/IPNS results properly. Detection is server-side (the extension calls the shared worker), so results already appear once the worker is deployed — this fixes the labeling and logo:

- New \`cid\` InputType → tag reads **CID** (blue), instead of falling back to "Transaction".
- IPFS/IPNS logo via the shared \`ipfs.svg\` glyph (served from multiscan.dev, verified 200 / image/svg+xml).
- CHANGELOG + README entries.

Verified: \`tsc\` clean, \`ray lint\` 0 errors.

## Note
This updates the **main repo** only. The store submission (raycast/extensions PR #29167) is still in review as the initial version and is intentionally left untouched — this becomes a follow-up PR there once #29167 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)