### PR TITLE
Add Midnight network support

### DIFF
--- a/raycast/src/chainLogos.ts
+++ b/raycast/src/chainLogos.ts
@@ -238,9 +238,12 @@ const CHAIN_LOGO_SLUG: Record<string, string> = {
 };
 
 export function getChainLogoUrl(chainName: string): string | undefined {
-  // IPFS/IPNS share a single SVG glyph (no .png slug).
+  // SVG glyphs (no .png slug).
   if (chainName === "IPFS" || chainName === "IPNS") {
     return "https://multiscan.dev/logos/ipfs.svg";
+  }
+  if (chainName === "Midnight" || chainName === "Midnight Testnet") {
+    return "https://multiscan.dev/logos/midnight.svg";
   }
   const slug = CHAIN_LOGO_SLUG[chainName];
   if (!slug) return undefined;

--- a/website/public/logos/midnight.svg
+++ b/website/public/logos/midnight.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Midnight</title><path fill="#4338CA" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>

--- a/website/src/chainLogos.ts
+++ b/website/src/chainLogos.ts
@@ -1,6 +1,8 @@
 const L = (file: string) => `/logos/${file}.png`;
 
 export const CHAIN_LOGO: Record<string, string> = {
+  Midnight: "/logos/midnight.svg",
+  "Midnight Testnet": "/logos/midnight.svg",
   // Content addressing (shared IPFS glyph)
   IPFS: "/logos/ipfs.svg",
   IPNS: "/logos/ipfs.svg",

--- a/website/src/components/ResultsList.tsx
+++ b/website/src/components/ResultsList.tsx
@@ -168,6 +168,7 @@ const CLOUD_ITEMS: CloudItem[] = [
   { type: "chain", name: "Dash" },
   { type: "chain", name: "IOTA" },
   { type: "chain", name: "Urbit" },
+  { type: "chain", name: "Midnight" },
   { type: "chain", name: "IPFS" },
   { type: "chain", name: "IPNS" },
   { type: "name", name: ".eth" },

--- a/worker/src/chains.test.ts
+++ b/worker/src/chains.test.ts
@@ -151,6 +151,8 @@ describe("CHAINS data integrity", () => {
       "iota",
       "ipfs",
       "ipns",
+      "midnight",
+      "midnight-testnet",
     ]);
     for (const chain of CHAINS) {
       if (unverifiable.has(chain.id)) continue;

--- a/worker/src/chains.ts
+++ b/worker/src/chains.ts
@@ -35,6 +35,7 @@ export type FormatFamily =
   | "nockchain"
   | "stacks"
   | "ipfs"
+  | "midnight"
   | "bitcoin-testnet";
 
 export type InputType =
@@ -5001,6 +5002,39 @@ export const CHAINS: Chain[] = [
         keyEnvVar: "ALCHEMY_API_KEY",
       },
     ],
+  },
+
+  // --- Midnight (privacy sidechain; unshielded bech32m addresses) ---
+  {
+    id: "midnight",
+    name: "Midnight",
+    symbol: "NIGHT",
+    family: "midnight",
+    explorers: [
+      {
+        name: "Midnight Explorer",
+        baseUrl: "https://midnightexplorer.com",
+        addressPath: "/address/{query}",
+        txPath: "/transactions/{query}",
+      },
+    ],
+    rpcUrls: [],
+  },
+  {
+    id: "midnight-testnet",
+    name: "Midnight Testnet",
+    symbol: "tNIGHT",
+    family: "midnight",
+    isTestnet: true,
+    explorers: [
+      {
+        name: "Midnight Explorer",
+        baseUrl: "https://testnet.midnightexplorer.com",
+        addressPath: "/address/{query}",
+        txPath: "/transactions/{query}",
+      },
+    ],
+    rpcUrls: [],
   },
 
   // --- Content addressing (not a chain — gateways act as "explorers") ---

--- a/worker/src/detect.test.ts
+++ b/worker/src/detect.test.ts
@@ -1405,3 +1405,46 @@ describe("IPFS / IPNS detection", () => {
     expect(results[0].chain.id).toBe("solana");
   });
 });
+
+// --- Midnight ---
+
+describe("Midnight detection", () => {
+  // Representative bech32m unshielded addresses (mn_addr HRP)
+  const MAINNET =
+    "mn_addr1qxyzq0v9r5m8k3n7p2wl4t6h8s0d2f4g6j8k0m2n4p6r8t0v2w4y6a8c0e2g4";
+  const TESTNET =
+    "mn_addr_test1qxyzq0v9r5m8k3n7p2wl4t6h8s0d2f4g6j8k0m2n4p6r8t0v2w4y6a8c";
+
+  it("detects a mainnet unshielded address", () => {
+    const results = detect(MAINNET, CHAINS);
+    expect(results).toHaveLength(1);
+    expect(results[0].chain.id).toBe("midnight");
+    expect(results[0].inputType).toBe("address");
+    expect(results[0].explorerUrls[0].url).toBe(
+      `https://midnightexplorer.com/address/${MAINNET}`,
+    );
+  });
+
+  it("detects a testnet address as midnight-testnet", () => {
+    const results = detect(TESTNET, CHAINS);
+    expect(results).toHaveLength(1);
+    expect(results[0].chain.id).toBe("midnight-testnet");
+    expect(results[0].explorerUrls[0].url).toBe(
+      `https://testnet.midnightexplorer.com/address/${TESTNET}`,
+    );
+  });
+
+  it("detects preprod/preview testnet HRPs", () => {
+    for (const hrp of ["mn_addr_preprod1", "mn_addr_preview1"]) {
+      const addr = hrp + "qxyzq0v9r5m8k3n7p2wl4t6h8s0d2f4g6j8k0m2n4p6";
+      const results = detect(addr, CHAINS);
+      expect(results[0].chain.id).toBe("midnight-testnet");
+    }
+  });
+
+  it("does not match a Cardano addr1 address", () => {
+    const cardano = "addr1" + "q".repeat(90);
+    const results = detect(cardano, CHAINS);
+    expect(results.every((r) => r.chain.family !== "midnight")).toBe(true);
+  });
+});

--- a/worker/src/detect.ts
+++ b/worker/src/detect.ts
@@ -110,6 +110,17 @@ function getMatches(input: string): Match[] {
   const ipfsMatches = detectIpfs(trimmed);
   if (ipfsMatches.length > 0) return ipfsMatches;
 
+  // Midnight unshielded address (bech32m): mn_addr1… (mainnet),
+  // mn_addr_test1… / _preprod1… / _preview1… (testnet). HRP is unique, no collision.
+  if (/^mn_addr1[0-9a-z]{30,}$/.test(trimmed)) {
+    matches.push({ chainId: "midnight", inputType: "address" });
+    return matches;
+  }
+  if (/^mn_addr_(test|preprod|preview)1[0-9a-z]{30,}$/.test(trimmed)) {
+    matches.push({ chainId: "midnight-testnet", inputType: "address" });
+    return matches;
+  }
+
   // 0x + 40 hex chars = EVM address (42 chars total)
   if (/^0x[0-9a-fA-F]{40}$/i.test(trimmed)) {
     for (const id of EVM_CHAIN_IDS) {


### PR DESCRIPTION
[Midnight](https://midnight.network/) mainnet went live (genesis 2026-03-30). This detects its **unshielded bech32m addresses** and links to Midnight Explorer.

## Detection
- \`mn_addr1…\` → **Midnight** (mainnet)
- \`mn_addr_test1…\` / \`_preprod1…\` / \`_preview1…\` → **Midnight Testnet** (badged)
- The \`mn_addr\` HRP is unique → no collision (verified with a Cardano \`addr1\` negative test).

## Why no transaction detection
Midnight tx hashes are \`0x\`+64hex (Substrate-style), which **already matches ~20 chains** (EVM/Sui/Aptos/…). Adding Midnight to that pile would just add noise to every EVM tx lookup and couldn't disambiguate. The bech32m address is the clean, unique discriminator.

## Explorer
[midnightexplorer.com](https://midnightexplorer.com) — \`/address/{addr}\`, \`/transactions/{hash}\` (testnet on \`testnet.midnightexplorer.com\`). Both path shapes return 200 and the indexer accepts bech32m addresses. Crescent-moon SVG logo; wired into website + extension.

## Caveats
- Midnight is in an early **guarded/federated phase** — limited public activity, so many lookups may show sparse data.
- **Shielded** (private) addresses aren't publicly viewable by design; only unshielded \`mn_addr\` addresses are detected.

## Verification
- worker \`tsc\` clean, **286 tests pass** (new Midnight suite)
- website builds clean; raycast \`tsc\` clean

**Not deployed to prod yet** — awaiting go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)